### PR TITLE
[Refactor] SharedPreferences를 Preferences DataStore로 변경

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,9 @@ reviews:
         - expect / actual 분리가 필요한 코드가 commonMain에 포함되지 않았는지
         - Coroutine / Flow 사용이 멀티플랫폼 환경에서 안전한지
         - Compose 공통 UI가 특정 플랫폼 동작을 가정하지 않는지
-        - "하드코딩된 값(문자열, 숫자, URL, 키 등)을 반드시 지적하고, 상수 또는 설정 파일로 분리하도록 제안하세요."
+        - 하드코딩된 값(문자열, 숫자, URL, 키 등)을 반드시 지적하고, 상수 또는 설정 파일로 분리하도록 제안하세요.
+        - Dependency Injection은 **Metro DI**를 사용하고 있으므로,Hilt/Koin 기준이 아닌 Metro 기준으로 리뷰해 주세요.
+        - @Provides, @ContributesBinding, component 구조 등 Metro 패턴에 맞는지 확인해 주세요.
 
         각 리뷰 지적에는 가능하면 Kotlin Multiplatform 또는
         Compose Multiplatform 공식 문서를 근거 링크로 첨부해 주세요.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
+            export("dev.zacsweers.metro:runtime:0.9.4")
         }
     }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -66,6 +66,8 @@ kotlin {
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.kotlinx.datetime)
+            implementation(libs.androidx.datastore)
+            implementation(libs.androidx.datastore.preferences)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
-            export("dev.zacsweers.metro:runtime:0.9.4")
+            export(libs.metro.runtime)
         }
     }
 

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".FestabookApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/FestabookApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/FestabookApp.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook
+
+import android.app.Application
+import com.daedan.festabook.di.AndroidAppGraph
+import dev.zacsweers.metro.createGraphFactory
+
+class FestabookApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        createGraphFactory<AndroidAppGraph.Factory>().create(this)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
@@ -1,0 +1,16 @@
+package com.daedan.festabook.di
+
+import android.app.Application
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+
+@DependencyGraph(AppScope::class)
+interface AndroidAppGraph : FestabookAppGraph {
+    @DependencyGraph.Factory
+    fun interface Factory {
+        fun create(
+            @Provides application: Application,
+        ): AndroidAppGraph
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,5 +19,6 @@ interface AndroidAppGraph : FestabookAppGraph {
     }
 
     @Provides
+    @SingleIn(AppScope::class)
     fun provideCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 @DependencyGraph(AppScope::class)
 interface AndroidAppGraph : FestabookAppGraph {
@@ -13,4 +16,7 @@ interface AndroidAppGraph : FestabookAppGraph {
             @Provides application: Application,
         ): AndroidAppGraph
     }
+
+    @Provides
+    fun provideCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
@@ -9,12 +9,14 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import okio.Path.Companion.toPath
 
 @BindingContainer
 @ContributesTo(AppScope::class)
 object DatabaseBindings {
     @Provides
+    @SingleIn(AppScope::class)
     fun provideDataStore(application: Application): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath {
             application.filesDir

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.di
+
+import android.app.Application
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.daedan.festabook.data.db.DATASTORE_FILE_NAME
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import okio.Path.Companion.toPath
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+object DatabaseBindings {
+    @Provides
+    fun provideDataStore(application: Application): DataStore<Preferences> =
+        PreferenceDataStoreFactory.createWithPath {
+            application.filesDir
+                .resolve(DATASTORE_FILE_NAME)
+                .absolutePath
+                .toPath()
+        }
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
@@ -2,15 +2,17 @@ package com.daedan.festabook.di
 
 import android.app.Application
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import com.daedan.festabook.data.db.DATASTORE_FILE_NAME
+import com.daedan.festabook.data.db.OLD_PREFS_FILE_NAME
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
-import okio.Path.Companion.toPath
 
 @BindingContainer
 @ContributesTo(AppScope::class)
@@ -18,10 +20,8 @@ object DatabaseBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideDataStore(application: Application): DataStore<Preferences> =
-        PreferenceDataStoreFactory.createWithPath {
-            application.filesDir
-                .resolve(DATASTORE_FILE_NAME)
-                .absolutePath
-                .toPath()
-        }
+        PreferenceDataStoreFactory.create(
+            migrations = listOf(SharedPreferencesMigration(application, OLD_PREFS_FILE_NAME)),
+            produceFile = { application.preferencesDataStoreFile(DATASTORE_FILE_NAME) },
+        )
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.Flow
 interface DeviceLocalDataSource {
     suspend fun saveUuid(uuid: String)
 
-    suspend fun getUuid(): Flow<String?>
+    fun getUuid(): Flow<String?>
 
     suspend fun saveDeviceId(deviceId: Long)
 
-    suspend fun getDeviceId(): Flow<Long?>
+    fun getDeviceId(): Flow<Long?>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
@@ -1,11 +1,13 @@
 package com.daedan.festabook.data.datasource.local
 
+import kotlinx.coroutines.flow.Flow
+
 interface DeviceLocalDataSource {
     suspend fun saveUuid(uuid: String)
 
-    suspend fun getUuid(): String?
+    suspend fun getUuid(): Flow<String?>
 
     suspend fun saveDeviceId(deviceId: Long)
 
-    suspend fun getDeviceId(): Long?
+    suspend fun getDeviceId(): Flow<Long?>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSource.kt
@@ -1,11 +1,11 @@
 package com.daedan.festabook.data.datasource.local
 
 interface DeviceLocalDataSource {
-    fun saveUuid(uuid: String)
+    suspend fun saveUuid(uuid: String)
 
-    fun getUuid(): String?
+    suspend fun getUuid(): String?
 
-    fun saveDeviceId(deviceId: Long)
+    suspend fun saveDeviceId(deviceId: Long)
 
-    fun getDeviceId(): Long?
+    suspend fun getDeviceId(): Long?
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.data.datasource.local
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
@@ -27,7 +28,7 @@ class DeviceLocalDataSourceImpl(
     override fun getUuid(): Flow<String?> =
         dataStore.data
             .catch {
-                emit(emptyPreferences())
+                if (it is IOException) emit(emptyPreferences()) else throw it
             }.map { it[KEY_UUID] }
 
     override suspend fun saveDeviceId(deviceId: Long) {
@@ -39,7 +40,7 @@ class DeviceLocalDataSourceImpl(
     override fun getDeviceId(): Flow<Long?> =
         dataStore.data
             .catch {
-                emit(emptyPreferences())
+                if (it is IOException) emit(emptyPreferences()) else throw it
             }.map { it[KEY_DEVICE_ID] }
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
@@ -3,12 +3,15 @@ package com.daedan.festabook.data.datasource.local
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -21,12 +24,11 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getUuid(): String? =
-        runCatching {
-            dataStore.data.first()[KEY_UUID]
-        }.onFailure {
-            TODO("추후 예외로그 추가")
-        }.getOrNull()
+    override suspend fun getUuid(): Flow<String?> =
+        dataStore.data
+            .catch {
+                emit(emptyPreferences())
+            }.map { it[KEY_UUID] }
 
     override suspend fun saveDeviceId(deviceId: Long) {
         dataStore.edit { preferences ->
@@ -34,12 +36,11 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getDeviceId(): Long? =
-        runCatching {
-            dataStore.data.first()[KEY_DEVICE_ID]
-        }.onFailure {
-            TODO("추후 예외로그 추가")
-        }.getOrNull()
+    override suspend fun getDeviceId(): Flow<Long?> =
+        dataStore.data
+            .catch {
+                emit(emptyPreferences())
+            }.map { it[KEY_DEVICE_ID] }
 
     companion object {
         private val KEY_DEVICE_ID = longPreferencesKey("server_device_id")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
@@ -1,34 +1,38 @@
 package com.daedan.festabook.data.datasource.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
 class DeviceLocalDataSourceImpl(
-    private val prefs: SharedPreferences,
+    private val dataStore: DataStore<Preferences>,
 ) : DeviceLocalDataSource {
-    override fun saveUuid(uuid: String) {
-        prefs.edit { putString(KEY_UUID, uuid) }
+    override suspend fun saveUuid(uuid: String) {
+        dataStore.edit { preferences ->
+            preferences[KEY_UUID] = uuid
+        }
     }
 
-    override fun getUuid(): String? = prefs.getString(KEY_UUID, null)
+    override suspend fun getUuid(): String? = dataStore.data.firstOrNull()?.get(KEY_UUID)
 
-    override fun saveDeviceId(deviceId: Long) {
-        prefs.edit { putLong(KEY_DEVICE_ID, deviceId) }
+    override suspend fun saveDeviceId(deviceId: Long) {
+        dataStore.edit { preferences ->
+            preferences[KEY_DEVICE_ID] = deviceId
+        }
     }
 
-    override fun getDeviceId(): Long? {
-        val deviceId = prefs.getLong(KEY_DEVICE_ID, DEFAULT_DEVICE_ID)
-        return if (deviceId == DEFAULT_DEVICE_ID) null else deviceId
-    }
+    override suspend fun getDeviceId(): Long? = dataStore.data.firstOrNull()?.get(KEY_DEVICE_ID)
 
     companion object {
-        private const val DEFAULT_DEVICE_ID = -1L
-        private const val KEY_DEVICE_ID = "server_device_id"
-        private const val KEY_UUID = "device_uuid"
+        private val KEY_DEVICE_ID = longPreferencesKey("server_device_id")
+        private val KEY_UUID = stringPreferencesKey("device_uuid")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
@@ -8,7 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -21,7 +21,12 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getUuid(): String? = dataStore.data.firstOrNull()?.get(KEY_UUID)
+    override suspend fun getUuid(): String? =
+        runCatching {
+            dataStore.data.first()[KEY_UUID]
+        }.onFailure {
+            TODO("추후 예외로그 추가")
+        }.getOrNull()
 
     override suspend fun saveDeviceId(deviceId: Long) {
         dataStore.edit { preferences ->
@@ -29,7 +34,12 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getDeviceId(): Long? = dataStore.data.firstOrNull()?.get(KEY_DEVICE_ID)
+    override suspend fun getDeviceId(): Long? =
+        runCatching {
+            dataStore.data.first()[KEY_DEVICE_ID]
+        }.onFailure {
+            TODO("추후 예외로그 추가")
+        }.getOrNull()
 
     companion object {
         private val KEY_DEVICE_ID = longPreferencesKey("server_device_id")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/DeviceLocalDataSourceImpl.kt
@@ -24,7 +24,7 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getUuid(): Flow<String?> =
+    override fun getUuid(): Flow<String?> =
         dataStore.data
             .catch {
                 emit(emptyPreferences())
@@ -36,7 +36,7 @@ class DeviceLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getDeviceId(): Flow<Long?> =
+    override fun getDeviceId(): Flow<Long?> =
         dataStore.data
             .catch {
                 emit(emptyPreferences())

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.datasource.local
 
 interface FcmDataSource {
-    fun saveFcmToken(token: String)
+    suspend fun saveFcmToken(token: String)
 
-    fun getFcmToken(): String?
+    suspend fun getFcmToken(): String?
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
@@ -1,7 +1,9 @@
 package com.daedan.festabook.data.datasource.local
 
+import kotlinx.coroutines.flow.Flow
+
 interface FcmDataSource {
     suspend fun saveFcmToken(token: String)
 
-    suspend fun getFcmToken(): String?
+    suspend fun getFcmToken(): Flow<String?>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSource.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.flow.Flow
 interface FcmDataSource {
     suspend fun saveFcmToken(token: String)
 
-    suspend fun getFcmToken(): Flow<String?>
+    fun getFcmToken(): Flow<String?>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
@@ -7,11 +7,11 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
-class FcmDataSourceImpl constructor(
+class FcmDataSourceImpl(
     private val dataStore: DataStore<Preferences>,
 ) : FcmDataSource {
     override suspend fun saveFcmToken(token: String) {
@@ -20,7 +20,12 @@ class FcmDataSourceImpl constructor(
         }
     }
 
-    override suspend fun getFcmToken(): String? = dataStore.data.firstOrNull()?.get(KEY_FCM_TOKEN)
+    override suspend fun getFcmToken(): String? =
+        runCatching {
+            dataStore.data.first()[KEY_FCM_TOKEN]
+        }.onFailure {
+            TODO("추후 예외로그 추가")
+        }.getOrNull()
 
     companion object {
         private val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
@@ -3,11 +3,14 @@ package com.daedan.festabook.data.datasource.local
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -20,12 +23,7 @@ class FcmDataSourceImpl(
         }
     }
 
-    override suspend fun getFcmToken(): String? =
-        runCatching {
-            dataStore.data.first()[KEY_FCM_TOKEN]
-        }.onFailure {
-            TODO("추후 예외로그 추가")
-        }.getOrNull()
+    override suspend fun getFcmToken(): Flow<String?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FCM_TOKEN] }
 
     companion object {
         private val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
@@ -1,23 +1,28 @@
 package com.daedan.festabook.data.datasource.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
 class FcmDataSourceImpl constructor(
-    private val prefs: SharedPreferences,
+    private val dataStore: DataStore<Preferences>,
 ) : FcmDataSource {
-    override fun saveFcmToken(token: String) {
-        prefs.edit { putString(KEY_FCM_TOKEN, token) }
+    override suspend fun saveFcmToken(token: String) {
+        dataStore.edit { preferences ->
+            preferences[KEY_FCM_TOKEN] = token
+        }
     }
 
-    override fun getFcmToken(): String? = prefs.getString(KEY_FCM_TOKEN, null)
+    override suspend fun getFcmToken(): String? = dataStore.data.firstOrNull()?.get(KEY_FCM_TOKEN)
 
     companion object {
-        private const val KEY_FCM_TOKEN = "fcm_token"
+        private val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.data.datasource.local
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
@@ -23,7 +24,11 @@ class FcmDataSourceImpl(
         }
     }
 
-    override fun getFcmToken(): Flow<String?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FCM_TOKEN] }
+    override fun getFcmToken(): Flow<String?> =
+        dataStore.data
+            .catch {
+                if (it is IOException) emit(emptyPreferences()) else throw it
+            }.map { it[KEY_FCM_TOKEN] }
 
     companion object {
         private val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FcmDataSourceImpl.kt
@@ -23,7 +23,7 @@ class FcmDataSourceImpl(
         }
     }
 
-    override suspend fun getFcmToken(): Flow<String?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FCM_TOKEN] }
+    override fun getFcmToken(): Flow<String?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FCM_TOKEN] }
 
     companion object {
         private val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -1,9 +1,9 @@
 package com.daedan.festabook.data.datasource.local
 
 interface FestivalLocalDataSource {
-    fun saveFestivalId(festivalId: Long)
+    suspend fun saveFestivalId(festivalId: Long)
 
-    fun getFestivalId(): Long?
+    suspend fun getFestivalId(): Long?
 
-    fun getIsFirstVisit(): Boolean
+    suspend fun getIsFirstVisit(): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -7,5 +7,5 @@ interface FestivalLocalDataSource {
 
     suspend fun getFestivalId(): Flow<Long?>
 
-    suspend fun getIsFirstVisit(festivalId: Long): Boolean
+    suspend fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface FestivalLocalDataSource {
     suspend fun saveFestivalId(festivalId: Long)
 
-    suspend fun getFestivalId(): Flow<Long?>
+    fun getFestivalId(): Flow<Long?>
 
-    suspend fun getIsFirstVisit(): Flow<Boolean>
+    fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -1,9 +1,11 @@
 package com.daedan.festabook.data.datasource.local
 
+import kotlinx.coroutines.flow.Flow
+
 interface FestivalLocalDataSource {
     suspend fun saveFestivalId(festivalId: Long)
 
-    suspend fun getFestivalId(): Long?
+    suspend fun getFestivalId(): Flow<Long?>
 
-    suspend fun getIsFirstVisit(): Boolean
+    suspend fun getIsFirstVisit(festivalId: Long): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -1,41 +1,39 @@
 package com.daedan.festabook.data.datasource.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
 class FestivalLocalDataSourceImpl(
-    private val prefs: SharedPreferences,
+    private val dataStore: DataStore<Preferences>,
 ) : FestivalLocalDataSource {
-    override fun saveFestivalId(festivalId: Long) {
-        prefs.edit { putLong(KEY_FESTIVAL_ID, festivalId) }
-    }
-
-    override fun getFestivalId(): Long? {
-        val id = prefs.getLong(KEY_FESTIVAL_ID, DEFAULT_FESTIVAL_ID)
-        return if (id == DEFAULT_FESTIVAL_ID) null else id
-    }
-
-    override fun getIsFirstVisit(): Boolean {
-        val festivalId = getFestivalId() ?: return true
-        val isFirstVisit =
-            prefs.getBoolean(
-                "${KEY_IS_FIRST_VISIT}_$festivalId",
-                true,
-            )
-        if (isFirstVisit) {
-            prefs.edit { putBoolean("${KEY_IS_FIRST_VISIT}_$festivalId", false) }
+    override suspend fun saveFestivalId(festivalId: Long) {
+        dataStore.edit { preferences ->
+            preferences[KEY_FESTIVAL_ID] = festivalId
         }
+    }
+
+    override suspend fun getFestivalId(): Long? = dataStore.data.firstOrNull()?.get(KEY_FESTIVAL_ID)
+
+    override suspend fun getIsFirstVisit(): Boolean {
+        val festivalId = getFestivalId() ?: return true
+        val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")
+        val isFirstVisit = dataStore.data.firstOrNull()?.get(key) ?: true
+
+        if (isFirstVisit) dataStore.edit { preferences -> preferences[key] = false }
         return isFirstVisit
     }
 
     companion object {
         private const val KEY_IS_FIRST_VISIT = "is_first_visit"
-        private const val KEY_FESTIVAL_ID = "festival_id"
-        private const val DEFAULT_FESTIVAL_ID = -1L
+        private val KEY_FESTIVAL_ID = longPreferencesKey("festival_id")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -27,10 +27,10 @@ class FestivalLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getFestivalId(): Flow<Long?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FESTIVAL_ID] }
+    override fun getFestivalId(): Flow<Long?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FESTIVAL_ID] }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun getIsFirstVisit(): Flow<Boolean> =
+    override fun getIsFirstVisit(): Flow<Boolean> =
         getFestivalId().flatMapLatest { festivalId ->
             val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")
             var isFirstVisit = true

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -8,7 +8,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -21,12 +21,19 @@ class FestivalLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getFestivalId(): Long? = dataStore.data.firstOrNull()?.get(KEY_FESTIVAL_ID)
+    override suspend fun getFestivalId(): Long? =
+        runCatching { dataStore.data.first()[KEY_FESTIVAL_ID] }
+            .onFailure {
+                TODO("추후 예외로그 추가")
+            }.getOrNull()
 
     override suspend fun getIsFirstVisit(): Boolean {
         val festivalId = getFestivalId() ?: return true
         val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")
-        val isFirstVisit = dataStore.data.firstOrNull()?.get(key) ?: true
+        val isFirstVisit =
+            runCatching { dataStore.data.first()[key] }
+                .onFailure { TODO("추후 예외로그 추가") }
+                .getOrNull() ?: true
 
         if (isFirstVisit) dataStore.edit { preferences -> preferences[key] = false }
         return isFirstVisit

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.data.datasource.local
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -27,7 +28,11 @@ class FestivalLocalDataSourceImpl(
         }
     }
 
-    override fun getFestivalId(): Flow<Long?> = dataStore.data.catch { emit(emptyPreferences()) }.map { it[KEY_FESTIVAL_ID] }
+    override fun getFestivalId(): Flow<Long?> =
+        dataStore.data
+            .catch {
+                if (it is IOException) emit(emptyPreferences()) else throw it
+            }.map { it[KEY_FESTIVAL_ID] }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getIsFirstVisit(): Flow<Boolean> =

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -1,12 +1,14 @@
 package com.daedan.festabook.data.datasource.local
 
+import kotlinx.coroutines.flow.Flow
+
 interface FestivalNotificationLocalDataSource {
     suspend fun saveFestivalNotificationId(
         festivalId: Long,
         festivalNotificationId: Long,
     )
 
-    suspend fun getFestivalNotificationId(festivalId: Long): Long
+    suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long>
 
     suspend fun deleteFestivalNotificationId(festivalId: Long)
 
@@ -15,5 +17,5 @@ interface FestivalNotificationLocalDataSource {
         isAllowed: Boolean,
     )
 
-    suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean
+    suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -8,7 +8,7 @@ interface FestivalNotificationLocalDataSource {
         festivalNotificationId: Long,
     )
 
-    suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long>
+    suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long?>
 
     suspend fun deleteFestivalNotificationId(festivalId: Long)
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -8,7 +8,7 @@ interface FestivalNotificationLocalDataSource {
         festivalNotificationId: Long,
     )
 
-    suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long?>
+    fun getFestivalNotificationId(festivalId: Long): Flow<Long?>
 
     suspend fun deleteFestivalNotificationId(festivalId: Long)
 
@@ -17,5 +17,5 @@ interface FestivalNotificationLocalDataSource {
         isAllowed: Boolean,
     )
 
-    suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean>
+    fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -1,21 +1,21 @@
 package com.daedan.festabook.data.datasource.local
 
 interface FestivalNotificationLocalDataSource {
-    fun saveFestivalNotificationId(
+    suspend fun saveFestivalNotificationId(
         festivalId: Long,
         festivalNotificationId: Long,
     )
 
-    fun getFestivalNotificationId(festivalId: Long): Long
+    suspend fun getFestivalNotificationId(festivalId: Long): Long
 
-    fun deleteFestivalNotificationId(festivalId: Long)
+    suspend fun deleteFestivalNotificationId(festivalId: Long)
 
-    fun clearAll()
+    suspend fun clearAll()
 
-    fun saveFestivalNotificationIsAllowed(
+    suspend fun saveFestivalNotificationIsAllowed(
         festivalId: Long,
         isAllowed: Boolean,
     )
 
-    fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean
+    suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSource.kt
@@ -10,8 +10,6 @@ interface FestivalNotificationLocalDataSource {
 
     suspend fun deleteFestivalNotificationId(festivalId: Long)
 
-    suspend fun clearAll()
-
     suspend fun saveFestivalNotificationIsAllowed(
         festivalId: Long,
         isAllowed: Boolean,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.data.datasource.local
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -32,7 +33,7 @@ class FestivalNotificationLocalDataSourceImpl(
         val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
         return dataStore.data
             .catch {
-                emit(emptyPreferences())
+                if (it is IOException) emit(emptyPreferences()) else throw it
             }.map { it[key] }
     }
 
@@ -53,7 +54,7 @@ class FestivalNotificationLocalDataSourceImpl(
         val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
         return dataStore.data
             .catch {
-                emit(emptyPreferences())
+                if (it is IOException) emit(emptyPreferences()) else throw it
             }.map { it[key] ?: false }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -38,10 +38,6 @@ class FestivalNotificationLocalDataSourceImpl(
         dataStore.edit { preferences -> preferences.remove(key) }
     }
 
-    override suspend fun clearAll() {
-        dataStore.edit { preferences -> preferences.clear() }
-    }
-
     override suspend fun saveFestivalNotificationIsAllowed(
         festivalId: Long,
         isAllowed: Boolean,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -8,7 +8,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -27,7 +27,10 @@ class FestivalNotificationLocalDataSourceImpl(
 
     override suspend fun getFestivalNotificationId(festivalId: Long): Long {
         val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
-        return dataStore.data.firstOrNull()?.get(key) ?: DEFAULT_FESTIVAL_NOTIFICATION_ID
+        return runCatching { dataStore.data.first()[key] }
+            .onFailure { TODO("추후 예외로그 추가") }
+            .getOrNull()
+            ?: DEFAULT_FESTIVAL_NOTIFICATION_ID
     }
 
     override suspend fun deleteFestivalNotificationId(festivalId: Long) {
@@ -49,7 +52,9 @@ class FestivalNotificationLocalDataSourceImpl(
 
     override suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean {
         val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
-        return dataStore.data.firstOrNull()?.get(key) ?: false
+        return runCatching { dataStore.data.first()[key] }
+            .onFailure { TODO("추후 예외로그 추가") }
+            .getOrNull() ?: false
     }
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -28,12 +28,12 @@ class FestivalNotificationLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long> {
+    override suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long?> {
         val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
         return dataStore.data
             .catch {
                 emit(emptyPreferences())
-            }.map { it[key] ?: DEFAULT_FESTIVAL_NOTIFICATION_ID }
+            }.map { it[key] }
     }
 
     override suspend fun deleteFestivalNotificationId(festivalId: Long) {
@@ -59,7 +59,6 @@ class FestivalNotificationLocalDataSourceImpl(
 
     companion object {
         private const val KEY_FESTIVAL_NOTIFICATION_ID = "festival_notification_id"
-        private const val DEFAULT_FESTIVAL_NOTIFICATION_ID = -1L
         private const val KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED = "key_festival_notification_allowed"
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -4,11 +4,14 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -25,12 +28,12 @@ class FestivalNotificationLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getFestivalNotificationId(festivalId: Long): Long {
+    override suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long> {
         val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
-        return runCatching { dataStore.data.first()[key] }
-            .onFailure { TODO("추후 예외로그 추가") }
-            .getOrNull()
-            ?: DEFAULT_FESTIVAL_NOTIFICATION_ID
+        return dataStore.data
+            .catch {
+                emit(emptyPreferences())
+            }.map { it[key] ?: DEFAULT_FESTIVAL_NOTIFICATION_ID }
     }
 
     override suspend fun deleteFestivalNotificationId(festivalId: Long) {
@@ -46,11 +49,12 @@ class FestivalNotificationLocalDataSourceImpl(
         dataStore.edit { preferences -> preferences[key] = isAllowed }
     }
 
-    override suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean {
+    override suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean> {
         val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
-        return runCatching { dataStore.data.first()[key] }
-            .onFailure { TODO("추후 예외로그 추가") }
-            .getOrNull() ?: false
+        return dataStore.data
+            .catch {
+                emit(emptyPreferences())
+            }.map { it[key] ?: false }
     }
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -42,7 +42,7 @@ class FestivalNotificationLocalDataSourceImpl(
         festivalId: Long,
         isAllowed: Boolean,
     ) {
-        val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
+        val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
         dataStore.edit { preferences -> preferences[key] = isAllowed }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -1,59 +1,56 @@
 package com.daedan.festabook.data.datasource.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
 class FestivalNotificationLocalDataSourceImpl(
-    private val prefs: SharedPreferences,
+    private val dataStore: DataStore<Preferences>,
 ) : FestivalNotificationLocalDataSource {
-    override fun saveFestivalNotificationId(
+    override suspend fun saveFestivalNotificationId(
         festivalId: Long,
         festivalNotificationId: Long,
     ) {
-        prefs.edit {
-            putLong(
-                "${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId",
-                festivalNotificationId,
-            )
+        val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
+        dataStore.edit { preferences ->
+            preferences[key] = festivalNotificationId
         }
     }
 
-    override fun getFestivalNotificationId(festivalId: Long): Long =
-        prefs.getLong(
-            "${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId",
-            DEFAULT_FESTIVAL_NOTIFICATION_ID,
-        )
-
-    override fun deleteFestivalNotificationId(festivalId: Long) {
-        prefs.edit { remove("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId") }
+    override suspend fun getFestivalNotificationId(festivalId: Long): Long {
+        val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
+        return dataStore.data.firstOrNull()?.get(key) ?: DEFAULT_FESTIVAL_NOTIFICATION_ID
     }
 
-    override fun clearAll() {
-        prefs.edit { clear() }
+    override suspend fun deleteFestivalNotificationId(festivalId: Long) {
+        val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
+        dataStore.edit { preferences -> preferences.remove(key) }
     }
 
-    override fun saveFestivalNotificationIsAllowed(
+    override suspend fun clearAll() {
+        dataStore.edit { preferences -> preferences.clear() }
+    }
+
+    override suspend fun saveFestivalNotificationIsAllowed(
         festivalId: Long,
         isAllowed: Boolean,
     ) {
-        prefs.edit {
-            putBoolean(
-                "${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId",
-                isAllowed,
-            )
-        }
+        val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
+        dataStore.edit { preferences -> preferences[key] = isAllowed }
     }
 
-    override fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean =
-        prefs.getBoolean(
-            "${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId",
-            false,
-        )
+    override suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Boolean {
+        val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
+        return dataStore.data.firstOrNull()?.get(key) ?: false
+    }
 
     companion object {
         private const val KEY_FESTIVAL_NOTIFICATION_ID = "festival_notification_id"

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalNotificationLocalDataSourceImpl.kt
@@ -28,7 +28,7 @@ class FestivalNotificationLocalDataSourceImpl(
         }
     }
 
-    override suspend fun getFestivalNotificationId(festivalId: Long): Flow<Long?> {
+    override fun getFestivalNotificationId(festivalId: Long): Flow<Long?> {
         val key = longPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_ID}_$festivalId")
         return dataStore.data
             .catch {
@@ -49,7 +49,7 @@ class FestivalNotificationLocalDataSourceImpl(
         dataStore.edit { preferences -> preferences[key] = isAllowed }
     }
 
-    override suspend fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean> {
+    override fun getFestivalNotificationIsAllowed(festivalId: Long): Flow<Boolean> {
         val key = booleanPreferencesKey("${KEY_FESTIVAL_NOTIFICATION_IS_ALLOWED}_$festivalId")
         return dataStore.data
             .catch {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceRemoteDataSource.kt
@@ -3,7 +3,7 @@ package com.daedan.festabook.data.datasource.remote.device
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.DeviceRegisterResponse
 
-interface DeviceDataSource {
+interface DeviceRemoteDataSource {
     suspend fun registerDevice(
         deviceIdentifier: String,
         fcmToken: String,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceRemoteDataSourceImpl.kt
@@ -10,9 +10,9 @@ import dev.zacsweers.metro.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
-class DeviceDataSourceImpl(
+class DeviceRemoteDataSourceImpl(
     private val deviceService: DeviceService,
-) : DeviceDataSource {
+) : DeviceRemoteDataSource {
     override suspend fun registerDevice(
         deviceIdentifier: String,
         fcmToken: String,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSource.kt
@@ -3,7 +3,7 @@ package com.daedan.festabook.data.datasource.remote.festival
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
 
-interface FestivalNotificationDataSource {
+interface FestivalNotificationRemoteDataSource {
     suspend fun saveFestivalNotification(
         festivalId: Long,
         deviceId: Long,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
@@ -10,9 +10,9 @@ import dev.zacsweers.metro.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
-class FestivalNotificationDataSourceImpl(
+class FestivalNotificationRemoteDataSourceImpl(
     private val festivalNotificationService: FestivalNotificationService,
-) : FestivalNotificationDataSource {
+) : FestivalNotificationRemoteDataSource {
     override suspend fun saveFestivalNotification(
         festivalId: Long,
         deviceId: Long,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
@@ -4,7 +4,7 @@ import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.UniversityResponse
 import com.daedan.festabook.data.model.response.festival.FestivalResponse
 
-interface FestivalDataSource {
+interface FestivalRemoteDataSource {
     suspend fun fetchFestival(): ApiResult<FestivalResponse>
 
     suspend fun findUniversitiesByName(universityName: String): ApiResult<List<UniversityResponse>>

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
@@ -10,9 +10,9 @@ import dev.zacsweers.metro.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
-class FestivalDataSourceImpl(
+class FestivalRemoteDataSourceImpl(
     private val festivalService: FestivalService,
-) : FestivalDataSource {
+) : FestivalRemoteDataSource {
     override suspend fun fetchFestival(): ApiResult<FestivalResponse> =
         ApiResult.toApiResult {
             festivalService.fetchOrganization()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/db/DatabaseFileName.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/db/DatabaseFileName.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook.data.db
+
+internal const val DATASTORE_FILE_NAME = "festabook_prefs.preferences"

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/db/DatabaseFileName.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/db/DatabaseFileName.kt
@@ -1,3 +1,7 @@
 package com.daedan.festabook.data.db
 
-internal const val DATASTORE_FILE_NAME = "festabook_prefs.preferences"
+// 기존에 있는 SharedPreferences 파일명
+internal const val OLD_PREFS_FILE_NAME = "app_prefs"
+
+// 새로운 DataStore의 파일명
+internal const val DATASTORE_FILE_NAME = "festabook_prefs"

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.daedan.festabook.data.repository
 
 import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
 import com.daedan.festabook.data.datasource.local.FcmDataSource
-import com.daedan.festabook.data.datasource.remote.device.DeviceDataSource
+import com.daedan.festabook.data.datasource.remote.device.DeviceRemoteDataSource
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.AppScope
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.first
 @ContributesBinding(AppScope::class)
 @Inject
 class DeviceRepositoryImpl(
-    private val deviceDataSource: DeviceDataSource,
+    private val deviceRemoteDataSource: DeviceRemoteDataSource,
     private val deviceLocalDataSource: DeviceLocalDataSource,
     private val fcmDataSource: FcmDataSource,
 ) : DeviceRepository {
@@ -22,7 +22,7 @@ class DeviceRepositoryImpl(
         fcmToken: String,
     ): Result<Long> {
         val response =
-            deviceDataSource
+            deviceRemoteDataSource
                 .registerDevice(
                     deviceIdentifier = deviceIdentifier,
                     fcmToken = fcmToken,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -8,7 +8,7 @@ import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -35,13 +35,13 @@ class DeviceRepositoryImpl(
     }
 
     override suspend fun getUuid(): String? =
-        deviceLocalDataSource.getUuid().first() ?: run {
+        deviceLocalDataSource.getUuid().firstOrNull() ?: run {
             // 로그 달아주세요잉
             null
         }
 
     override suspend fun getFcmToken(): String? =
-        fcmDataSource.getFcmToken().first() ?: run {
+        fcmDataSource.getFcmToken().firstOrNull() ?: run {
             // 로그 달아주세요잉
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
 import com.daedan.festabook.data.datasource.local.FcmDataSource
 import com.daedan.festabook.data.datasource.remote.device.DeviceRemoteDataSource
 import com.daedan.festabook.data.util.toResult
+import com.daedan.festabook.data.util.withTimeoutOrNullFallback
 import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -14,7 +15,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.withTimeoutOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -58,23 +58,19 @@ class DeviceRepositoryImpl(
     override suspend fun getUuid(): String? {
         cachedUuid.value?.let { return it }
 
-        return withTimeoutOrNull(2000) {
-            cachedUuid.value ?: cachedUuid.filterNotNull().first()
-        } ?: run {
-            // 로그
-            null
-        }
+        return withTimeoutOrNullFallback(
+            producer = { cachedUuid.value ?: cachedUuid.filterNotNull().first() },
+            onFallback = { /*TODO 로그 */ },
+        )
     }
 
     override suspend fun getFcmToken(): String? {
         cachedFcmToken.value?.let { return it }
 
-        return withTimeoutOrNull(2000) {
-            cachedFcmToken.value ?: cachedFcmToken.filterNotNull().first()
-        } ?: run {
-            // 로그
-            null
-        }
+        return withTimeoutOrNullFallback(
+            producer = { cachedFcmToken.value ?: cachedFcmToken.filterNotNull().first() },
+            onFallback = { /*TODO 로그 */ },
+        )
     }
 
     override suspend fun saveFcmToken(token: String) {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -29,15 +29,15 @@ class DeviceRepositoryImpl(
         return response.mapCatching { it.id }
     }
 
-    override fun saveDeviceId(deviceId: Long) {
+    override suspend fun saveDeviceId(deviceId: Long) {
         deviceLocalDataSource.saveDeviceId(deviceId)
     }
 
-    override fun getUuid(): String? = deviceLocalDataSource.getUuid()
+    override suspend fun getUuid(): String? = deviceLocalDataSource.getUuid()
 
-    override fun getFcmToken(): String? = fcmDataSource.getFcmToken()
+    override suspend fun getFcmToken(): String? = fcmDataSource.getFcmToken()
 
-    override fun saveFcmToken(token: String) {
+    override suspend fun saveFcmToken(token: String) {
         fcmDataSource.saveFcmToken(token)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -33,9 +34,17 @@ class DeviceRepositoryImpl(
         deviceLocalDataSource.saveDeviceId(deviceId)
     }
 
-    override suspend fun getUuid(): String? = deviceLocalDataSource.getUuid()
+    override suspend fun getUuid(): String? =
+        deviceLocalDataSource.getUuid().first() ?: run {
+            // 로그 달아주세요잉
+            null
+        }
 
-    override suspend fun getFcmToken(): String? = fcmDataSource.getFcmToken()
+    override suspend fun getFcmToken(): String? =
+        fcmDataSource.getFcmToken().first() ?: run {
+            // 로그 달아주세요잉
+            null
+        }
 
     override suspend fun saveFcmToken(token: String) {
         fcmDataSource.saveFcmToken(token)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -27,7 +27,7 @@ class ExploreRepositoryImpl(
         return response.mapCatching { universities -> universities.map { it.toDomain() } }
     }
 
-    override fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)
+    override suspend fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)
 
-    override fun getFestivalId(): Long? = festivalLocalDataSource.getFestivalId()
+    override suspend fun getFestivalId(): Long? = festivalLocalDataSource.getFestivalId()
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -9,7 +9,7 @@ import com.daedan.festabook.domain.repository.ExploreRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -31,7 +31,7 @@ class ExploreRepositoryImpl(
     override suspend fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)
 
     override suspend fun getFestivalId(): Long? =
-        festivalLocalDataSource.getFestivalId().first() ?: run {
+        festivalLocalDataSource.getFestivalId().firstOrNull() ?: run {
             // 로그 달아주세요잉
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.repository
 
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
-import com.daedan.festabook.data.datasource.remote.festival.FestivalDataSource
+import com.daedan.festabook.data.datasource.remote.festival.FestivalRemoteDataSource
 import com.daedan.festabook.data.model.response.toDomain
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.model.University
@@ -14,14 +14,14 @@ import kotlinx.coroutines.flow.first
 @ContributesBinding(AppScope::class)
 @Inject
 class ExploreRepositoryImpl(
-    private val festivalDataSource: FestivalDataSource,
+    private val festivalRemoteDataSource: FestivalRemoteDataSource,
     private val festivalLocalDataSource: FestivalLocalDataSource,
 ) : ExploreRepository {
     override suspend fun search(query: String): Result<List<University>> {
 //        Timber.d("Searching for query: $query")
 
         val response =
-            festivalDataSource
+            festivalRemoteDataSource
                 .findUniversitiesByName(universityName = query)
                 .toResult()
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.daedan.festabook.domain.repository.ExploreRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.first
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -29,5 +30,9 @@ class ExploreRepositoryImpl(
 
     override suspend fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)
 
-    override suspend fun getFestivalId(): Long? = festivalLocalDataSource.getFestivalId()
+    override suspend fun getFestivalId(): Long? =
+        festivalLocalDataSource.getFestivalId().first() ?: run {
+            // 로그 달아주세요잉
+            null
+        }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
 import com.daedan.festabook.data.datasource.remote.festival.FestivalRemoteDataSource
 import com.daedan.festabook.data.model.response.toDomain
 import com.daedan.festabook.data.util.toResult
+import com.daedan.festabook.data.util.withTimeoutOrNullFallback
 import com.daedan.festabook.domain.model.University
 import com.daedan.festabook.domain.repository.ExploreRepository
 import dev.zacsweers.metro.AppScope
@@ -31,8 +32,8 @@ class ExploreRepositoryImpl(
     override suspend fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)
 
     override suspend fun getFestivalId(): Long? =
-        festivalLocalDataSource.getFestivalId().firstOrNull() ?: run {
-            // 로그 달아주세요잉
-            null
-        }
+        withTimeoutOrNullFallback(
+            producer = { festivalLocalDataSource.getFestivalId().firstOrNull() },
+            onFallback = { /*TODO 로그 */ },
+        )
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -64,11 +64,12 @@ class FestivalNotificationRepositoryImpl(
                     // 여기에 로그 달아주세요잉
                     return Result.failure(IllegalStateException())
                 }
-        val response =
-            festivalNotificationRemoteDataSource.deleteFestivalNotification(festivalNotificationId)
-        festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
-
-        return response.toResult()
+        return festivalNotificationRemoteDataSource
+            .deleteFestivalNotification(festivalNotificationId)
+            .toResult()
+            .onSuccess {
+                festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
+            }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -58,12 +58,12 @@ class FestivalNotificationRepositoryImpl(
         return response.toResult()
     }
 
-    override fun getFestivalNotificationIsAllow(): Boolean {
+    override suspend fun getFestivalNotificationIsAllow(): Boolean {
         val festivalId = festivalLocalDataSource.getFestivalId() ?: return false
         return festivalNotificationLocalDataSource.getFestivalNotificationIsAllowed(festivalId)
     }
 
-    override fun setFestivalNotificationIsAllow(isAllowed: Boolean) {
+    override suspend fun setFestivalNotificationIsAllow(isAllowed: Boolean) {
         festivalLocalDataSource.getFestivalId()?.let { festivalId ->
             festivalNotificationLocalDataSource.saveFestivalNotificationIsAllowed(
                 festivalId,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 
@@ -25,12 +25,12 @@ class FestivalNotificationRepositoryImpl(
 ) : FestivalNotificationRepository {
     override suspend fun saveFestivalNotification(): Result<Unit> {
         val deviceId =
-            deviceLocalDataSource.getDeviceId().first() ?: run {
+            deviceLocalDataSource.getDeviceId().firstOrNull() ?: run {
 //            Timber.e("${this::class.simpleName}: DeviceId가 null 입니다.")
                 return Result.failure(IllegalStateException())
             }
         val festivalId =
-            festivalLocalDataSource.getFestivalId().first() ?: run {
+            festivalLocalDataSource.getFestivalId().firstOrNull() ?: run {
 //            Timber.e("${this::class.simpleName}festivalId가 null 입니다.")
                 return Result.failure(IllegalStateException())
             }
@@ -53,13 +53,13 @@ class FestivalNotificationRepositoryImpl(
 
     override suspend fun deleteFestivalNotification(): Result<Unit> {
         val festivalId =
-            festivalLocalDataSource.getFestivalId().first() ?: run {
+            festivalLocalDataSource.getFestivalId().firstOrNull() ?: run {
                 // 여기에 로그 달아주세요잉
                 return Result.failure(IllegalStateException())
             }
 
         val festivalNotificationId =
-            festivalNotificationLocalDataSource.getFestivalNotificationId(festivalId).first()
+            festivalNotificationLocalDataSource.getFestivalNotificationId(festivalId).firstOrNull()
                 ?: run {
                     // 여기에 로그 달아주세요잉
                     return Result.failure(IllegalStateException())
@@ -84,7 +84,7 @@ class FestivalNotificationRepositoryImpl(
         }
 
     override suspend fun setFestivalNotificationIsAllow(isAllowed: Boolean) {
-        festivalLocalDataSource.getFestivalId().first()?.let { festivalId ->
+        festivalLocalDataSource.getFestivalId().firstOrNull()?.let { festivalId ->
             festivalNotificationLocalDataSource.saveFestivalNotificationIsAllowed(
                 festivalId = festivalId,
                 isAllowed = isAllowed,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -67,7 +67,7 @@ class FestivalNotificationRepositoryImpl(
         return festivalNotificationRemoteDataSource
             .deleteFestivalNotification(festivalNotificationId)
             .toResult()
-            .onSuccess {
+            .mapCatching {
                 festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
             }
     }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.daedan.festabook.data.repository
 import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
 import com.daedan.festabook.data.datasource.local.FestivalNotificationLocalDataSource
-import com.daedan.festabook.data.datasource.remote.festival.FestivalNotificationDataSource
+import com.daedan.festabook.data.datasource.remote.festival.FestivalNotificationRemoteDataSource
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.domain.repository.FestivalNotificationRepository
 import dev.zacsweers.metro.AppScope
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.flowOf
 @ContributesBinding(AppScope::class)
 @Inject
 class FestivalNotificationRepositoryImpl(
-    private val festivalNotificationDataSource: FestivalNotificationDataSource,
+    private val festivalNotificationRemoteDataSource: FestivalNotificationRemoteDataSource,
     private val deviceLocalDataSource: DeviceLocalDataSource,
     private val festivalNotificationLocalDataSource: FestivalNotificationLocalDataSource,
     private val festivalLocalDataSource: FestivalLocalDataSource,
@@ -36,7 +36,7 @@ class FestivalNotificationRepositoryImpl(
             }
 
         val result =
-            festivalNotificationDataSource
+            festivalNotificationRemoteDataSource
                 .saveFestivalNotification(
                     festivalId = festivalId,
                     deviceId = deviceId,
@@ -65,7 +65,7 @@ class FestivalNotificationRepositoryImpl(
                     return Result.failure(IllegalStateException())
                 }
         val response =
-            festivalNotificationDataSource.deleteFestivalNotification(festivalNotificationId)
+            festivalNotificationRemoteDataSource.deleteFestivalNotification(festivalNotificationId)
         festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
 
         return response.toResult()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -73,7 +73,7 @@ class FestivalNotificationRepositoryImpl(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun getFestivalNotificationIsAllow(): Flow<Boolean> =
+    override fun getFestivalNotificationIsAllow(): Flow<Boolean> =
         festivalLocalDataSource.getFestivalId().flatMapLatest { festivalId ->
             if (festivalId == null) {
 //                    Timber.e("FestivalNotificationRepository: FestivalId가 null입니다")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -36,5 +36,5 @@ class FestivalRepositoryImpl(
         }
     }
 
-    override suspend fun getIsFirstVisit(): Flow<Boolean> = festivalLocalDataSource.getIsFirstVisit()
+    override fun getIsFirstVisit(): Flow<Boolean> = festivalLocalDataSource.getIsFirstVisit()
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -35,7 +35,7 @@ class FestivalRepositoryImpl(
         }
     }
 
-    override fun getIsFirstVisit(): Result<Boolean> =
+    override suspend fun getIsFirstVisit(): Result<Boolean> =
         runCatching {
             festivalLocalDataSource.getIsFirstVisit()
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.daedan.festabook.domain.repository.FestivalRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
 @ContributesBinding(AppScope::class)
@@ -35,8 +36,5 @@ class FestivalRepositoryImpl(
         }
     }
 
-    override suspend fun getIsFirstVisit(): Result<Boolean> =
-        runCatching {
-            festivalLocalDataSource.getIsFirstVisit()
-        }
+    override suspend fun getIsFirstVisit(): Flow<Boolean> = festivalLocalDataSource.getIsFirstVisit()
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.repository
 
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
-import com.daedan.festabook.data.datasource.remote.festival.FestivalDataSource
+import com.daedan.festabook.data.datasource.remote.festival.FestivalRemoteDataSource
 import com.daedan.festabook.data.datasource.remote.lineup.LineupDataSource
 import com.daedan.festabook.data.model.response.festival.toDomain
 import com.daedan.festabook.data.model.response.lineup.toDomain
@@ -18,12 +18,12 @@ import kotlinx.datetime.LocalDate
 @ContributesBinding(AppScope::class)
 @Inject
 class FestivalRepositoryImpl(
-    private val festivalDataSource: FestivalDataSource,
+    private val festivalRemoteDataSource: FestivalRemoteDataSource,
     private val festivalLocalDataSource: FestivalLocalDataSource,
     private val lineupDataSource: LineupDataSource,
 ) : FestivalRepository {
     override suspend fun getFestivalInfo(): Result<Organization> {
-        val response = festivalDataSource.fetchFestival().toResult()
+        val response = festivalRemoteDataSource.fetchFestival().toResult()
         return response.mapCatching { it.toDomain() }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/util/WithTimeoutOrNullFallback.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/util/WithTimeoutOrNullFallback.kt
@@ -1,0 +1,17 @@
+package com.daedan.festabook.data.util
+
+import kotlinx.coroutines.withTimeoutOrNull
+
+suspend fun <T> withTimeoutOrNullFallback(
+    timeMillis: Long = 2000L,
+    onFallback: () -> Unit = {},
+    producer: suspend () -> T?,
+): T? =
+    withTimeoutOrNull(
+        timeMillis = timeMillis,
+    ) {
+        producer()
+    } ?: run {
+        onFallback()
+        null
+    }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/FestabookAppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/FestabookAppGraph.kt
@@ -1,0 +1,4 @@
+package com.daedan.festabook.di
+
+// commonMain의 FestabookAppGraph에서 프로퍼티를 생성해서 사용할 필요가 있을 때를 대비해 정의해두었습니다.
+interface FestabookAppGraph

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/DeviceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/DeviceRepository.kt
@@ -6,11 +6,11 @@ interface DeviceRepository {
         fcmToken: String,
     ): Result<Long>
 
-    fun saveDeviceId(deviceId: Long)
+    suspend fun saveDeviceId(deviceId: Long)
 
-    fun getUuid(): String?
+    suspend fun getUuid(): String?
 
-    fun getFcmToken(): String?
+    suspend fun getFcmToken(): String?
 
-    fun saveFcmToken(token: String)
+    suspend fun saveFcmToken(token: String)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
@@ -5,7 +5,7 @@ import com.daedan.festabook.domain.model.University
 interface ExploreRepository {
     suspend fun search(query: String): Result<List<University>>
 
-    fun saveFestivalId(festivalId: Long)
+    suspend fun saveFestivalId(festivalId: Long)
 
-    fun getFestivalId(): Long?
+    suspend fun getFestivalId(): Long?
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
@@ -7,7 +7,7 @@ interface FestivalNotificationRepository {
 
     suspend fun deleteFestivalNotification(): Result<Unit>
 
-    suspend fun getFestivalNotificationIsAllow(): Flow<Boolean>
+    fun getFestivalNotificationIsAllow(): Flow<Boolean>
 
     suspend fun setFestivalNotificationIsAllow(isAllowed: Boolean)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
@@ -1,11 +1,13 @@
 package com.daedan.festabook.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
 interface FestivalNotificationRepository {
     suspend fun saveFestivalNotification(): Result<Unit>
 
     suspend fun deleteFestivalNotification(): Result<Unit>
 
-    suspend fun getFestivalNotificationIsAllow(): Boolean
+    suspend fun getFestivalNotificationIsAllow(): Flow<Boolean>
 
     suspend fun setFestivalNotificationIsAllow(isAllowed: Boolean)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
@@ -5,7 +5,7 @@ interface FestivalNotificationRepository {
 
     suspend fun deleteFestivalNotification(): Result<Unit>
 
-    fun getFestivalNotificationIsAllow(): Boolean
+    suspend fun getFestivalNotificationIsAllow(): Boolean
 
-    fun setFestivalNotificationIsAllow(isAllowed: Boolean)
+    suspend fun setFestivalNotificationIsAllow(isAllowed: Boolean)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.domain.repository
 
 import com.daedan.festabook.domain.model.LineupItem
 import com.daedan.festabook.domain.model.Organization
+import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
 interface FestivalRepository {
@@ -9,5 +10,5 @@ interface FestivalRepository {
 
     suspend fun getLineUpGroupByDate(): Result<Map<LocalDate, List<LineupItem>>>
 
-    suspend fun getIsFirstVisit(): Result<Boolean>
+    suspend fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -10,5 +10,5 @@ interface FestivalRepository {
 
     suspend fun getLineUpGroupByDate(): Result<Map<LocalDate, List<LineupItem>>>
 
-    suspend fun getIsFirstVisit(): Flow<Boolean>
+    fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalRepository.kt
@@ -9,5 +9,5 @@ interface FestivalRepository {
 
     suspend fun getLineUpGroupByDate(): Result<Map<LocalDate, List<LineupItem>>>
 
-    fun getIsFirstVisit(): Result<Boolean>
+    suspend fun getIsFirstVisit(): Result<Boolean>
 }

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
 import kotlinx.cinterop.ExperimentalForeignApi
 import okio.Path.Companion.toPath
 import platform.Foundation.NSDocumentDirectory
@@ -19,6 +20,7 @@ import platform.Foundation.NSUserDomainMask
 object DatabaseBindings {
     @OptIn(ExperimentalForeignApi::class)
     @Provides
+    @SingleIn(AppScope::class)
     fun provideDataStore(): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath {
             val documentDirectory =

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/DatabaseBindings.kt
@@ -1,0 +1,34 @@
+package com.daedan.festabook.di
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.daedan.festabook.data.db.DATASTORE_FILE_NAME
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+object DatabaseBindings {
+    @OptIn(ExperimentalForeignApi::class)
+    @Provides
+    fun provideDataStore(): DataStore<Preferences> =
+        PreferenceDataStoreFactory.createWithPath {
+            val documentDirectory =
+                NSFileManager.defaultManager.URLForDirectory(
+                    directory = NSDocumentDirectory,
+                    inDomain = NSUserDomainMask,
+                    appropriateForURL = null,
+                    create = false,
+                    error = null,
+                )
+            (requireNotNull(documentDirectory).path + "/$DATASTORE_FILE_NAME").toPath()
+        }
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/di/IosAppGraph.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.di
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.createGraph
+
+@DependencyGraph(AppScope::class)
+interface IosAppGraph : FestabookAppGraph
+
+fun createIosAppGraph() = createGraph<IosAppGraph>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorSerializationKotlinxJson" }
 ktorfit-converters-response = { module = "de.jensklingenberg.ktorfit:ktorfit-converters-response", version.ref = "ktorfit" }
 ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
+metro-runtime = { module = "dev.zacsweers.metro:metro-runtime", version.ref = "metro" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.6"
 androidx-testExt = "1.3.0"
 composeMultiplatform = "1.9.3"
+datastorePreferences = "1.2.0"
 junit = "4.13.2"
 kotlin = "2.2.20"
 kotlinxDatetime = "0.7.1"
@@ -23,6 +24,8 @@ buildkonfig = "0.17.1"
 ktlint = "14.0.1"
 
 [libraries]
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastorePreferences" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,7 +1,10 @@
 import SwiftUI
+import ComposeApp
 
 @main
 struct iOSApp: App {
+    let iosAppGraph = IosAppGraphKt.createIosAppGraph()
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## #️⃣ 이슈 번호

#11 

<br>

## 🛠️ 작업 내용

- SharedPreferences -> Preferences DataStore로 변경
- suspend 키워드 추가

<br>

## 🙇🏻 중점 리뷰 요청

- android의 `dataStore`를 생성하려면 `Context`가 필요해 의존성 그래프를 정의하여 주입했습니다. 놓친 부분 있으면 지적해주세요!
- 원래는 `DataStoreProvider`라는 `class`를 commonMain에 생성해서 `expect/actual`로 구분한 후, `context`는 `DataStoreProvider`의 `@Inject` 필드 주입으로 구현하려고 했으나 `class`에 `expect/actual`은 베타버전이라니 지양했습니다.
- 아니면 베타버전을 무시하고 구현한 후, 추후에 문제가 생겼을 때 해결하고 포폴에 트러블 슈팅으로 적는 것도 나쁘지 않을 것 같다는 생각도 드네요...ㅎㅎ(포트폴리오 주도 개발)

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * iOS 프레임워크에 Metro 런타임 포함
  * 플랫폼별 DI 그래프(안드로이드·iOS) 도입 및 앱 초기화 연동
  * iOS용 DataStore 제공자 추가

* **변경사항**
  * 로컬 영속성 전면 SharedPreferences → DataStore로 마이그레이션
  * 여러 API가 suspend/Flow 기반의 비동기/리액티브 인터페이스로 전환
  * 빌드에 DataStore 관련 라이브러리 추가

* **안정성 강화**
  * Android 애플리케이션 클래스 등록으로 초기화 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->