### PR TITLE
[Refactor] 축제 관련 api 변경에 따른 마이그레이션

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
@@ -1,11 +1,11 @@
 package com.daedan.festabook.data.datasource.remote.festival
 
 import com.daedan.festabook.data.datasource.remote.ApiResult
-import com.daedan.festabook.data.model.response.UniversityResponse
+import com.daedan.festabook.data.model.response.FestivalSearchResponse
 import com.daedan.festabook.data.model.response.festival.FestivalResponse
 
 interface FestivalRemoteDataSource {
     suspend fun fetchFestival(): ApiResult<FestivalResponse>
 
-    suspend fun findUniversitiesByName(universityName: String): ApiResult<List<UniversityResponse>>
+    suspend fun findUniversitiesByName(universityName: String): ApiResult<List<FestivalSearchResponse>>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSource.kt
@@ -7,5 +7,5 @@ import com.daedan.festabook.data.model.response.festival.FestivalResponse
 interface FestivalRemoteDataSource {
     suspend fun fetchFestival(): ApiResult<FestivalResponse>
 
-    suspend fun findUniversitiesByName(universityName: String): ApiResult<List<FestivalSearchResponse>>
+    suspend fun findFestivalsByKeyword(keyword: String): ApiResult<List<FestivalSearchResponse>>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.data.datasource.remote.festival
 
 import com.daedan.festabook.data.datasource.remote.ApiResult
-import com.daedan.festabook.data.model.response.UniversityResponse
+import com.daedan.festabook.data.model.response.FestivalSearchResponse
 import com.daedan.festabook.data.model.response.festival.FestivalResponse
 import com.daedan.festabook.data.service.FestivalService
 import dev.zacsweers.metro.AppScope
@@ -18,7 +18,7 @@ class FestivalRemoteDataSourceImpl(
             festivalService.fetchOrganization()
         }
 
-    override suspend fun findUniversitiesByName(universityName: String): ApiResult<List<UniversityResponse>> =
+    override suspend fun findUniversitiesByName(universityName: String): ApiResult<List<FestivalSearchResponse>> =
         ApiResult.toApiResult {
             festivalService.findFestivalsByKeyword(
                 keyword = universityName,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
@@ -18,10 +18,10 @@ class FestivalRemoteDataSourceImpl(
             festivalService.fetchOrganization()
         }
 
-    override suspend fun findUniversitiesByName(universityName: String): ApiResult<List<FestivalSearchResponse>> =
+    override suspend fun findFestivalsByKeyword(keyword: String): ApiResult<List<FestivalSearchResponse>> =
         ApiResult.toApiResult {
             festivalService.findFestivalsByKeyword(
-                keyword = universityName,
+                keyword = keyword,
             )
         }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
@@ -20,7 +20,7 @@ class FestivalRemoteDataSourceImpl(
 
     override suspend fun findUniversitiesByName(universityName: String): ApiResult<List<UniversityResponse>> =
         ApiResult.toApiResult {
-            festivalService.findUniversitiesByName(
+            festivalService.findFestivalsByKeyword(
                 keyword = universityName,
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceImpl.kt
@@ -21,7 +21,7 @@ class FestivalRemoteDataSourceImpl(
     override suspend fun findUniversitiesByName(universityName: String): ApiResult<List<UniversityResponse>> =
         ApiResult.toApiResult {
             festivalService.findUniversitiesByName(
-                universityName = universityName,
+                keyword = universityName,
             )
         }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/FestivalSearchResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/FestivalSearchResponse.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class FestivalSearchResponse(
     @SerialName("festivalId")
     val festivalId: Long,
-    @SerialName("universityName")
+    @SerialName("organizationName")
     val organizationName: String,
     @SerialName("festivalName")
     val festivalName: String,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/FestivalSearchResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/FestivalSearchResponse.kt
@@ -1,11 +1,11 @@
 package com.daedan.festabook.data.model.response
 
-import com.daedan.festabook.domain.model.University
+import com.daedan.festabook.domain.model.FestivalSearchItem
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UniversityResponse(
+data class FestivalSearchResponse(
     @SerialName("festivalId")
     val festivalId: Long,
     @SerialName("universityName")
@@ -18,10 +18,10 @@ data class UniversityResponse(
     val endDate: String,
 )
 
-fun UniversityResponse.toDomain() =
-    University(
+fun FestivalSearchResponse.toDomain() =
+    FestivalSearchItem(
         festivalId = festivalId,
-        universityName = organizationName,
+        organizationName = organizationName,
         festivalName = festivalName,
         startDate = startDate,
         endDate = endDate,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/UniversityResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/UniversityResponse.kt
@@ -9,7 +9,7 @@ data class UniversityResponse(
     @SerialName("festivalId")
     val festivalId: Long,
     @SerialName("universityName")
-    val universityName: String,
+    val organizationName: String,
     @SerialName("festivalName")
     val festivalName: String,
     @SerialName("startDate")
@@ -21,7 +21,7 @@ data class UniversityResponse(
 fun UniversityResponse.toDomain() =
     University(
         festivalId = festivalId,
-        universityName = universityName,
+        universityName = organizationName,
         festivalName = festivalName,
         startDate = startDate,
         endDate = endDate,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/FestivalResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/FestivalResponse.kt
@@ -36,7 +36,7 @@ data class FestivalResponse(
 fun FestivalResponse.toDomain() =
     Organization(
         id = id,
-        universityName = organizationName,
+        organizationName = organizationName,
         festival =
             Festival(
                 festivalImages = festivalImages.map { it.toDomain() },

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/FestivalResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/FestivalResponse.kt
@@ -11,8 +11,8 @@ import kotlinx.serialization.Serializable
 data class FestivalResponse(
     @SerialName("festivalId")
     val id: Long,
-    @SerialName("universityName")
-    val universityName: String,
+    @SerialName("organizationName")
+    val organizationName: String,
     @SerialName("festivalImages")
     val festivalImages: List<FestivalImage>,
     @SerialName("festivalName")
@@ -36,7 +36,7 @@ data class FestivalResponse(
 fun FestivalResponse.toDomain() =
     Organization(
         id = id,
-        universityName = universityName,
+        universityName = organizationName,
         festival =
             Festival(
                 festivalImages = festivalImages.map { it.toDomain() },

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.daedan.festabook.data.datasource.remote.festival.FestivalRemoteDataSo
 import com.daedan.festabook.data.model.response.toDomain
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.data.util.withTimeoutOrNullFallback
-import com.daedan.festabook.domain.model.University
+import com.daedan.festabook.domain.model.FestivalSearchItem
 import com.daedan.festabook.domain.repository.ExploreRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -18,7 +18,7 @@ class ExploreRepositoryImpl(
     private val festivalRemoteDataSource: FestivalRemoteDataSource,
     private val festivalLocalDataSource: FestivalLocalDataSource,
 ) : ExploreRepository {
-    override suspend fun search(query: String): Result<List<University>> {
+    override suspend fun search(query: String): Result<List<FestivalSearchItem>> {
 //        Timber.d("Searching for query: $query")
 
         val response =

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -23,10 +23,10 @@ class ExploreRepositoryImpl(
 
         val response =
             festivalRemoteDataSource
-                .findUniversitiesByName(universityName = query)
+                .findFestivalsByKeyword(keyword = query)
                 .toResult()
 
-        return response.mapCatching { universities -> universities.map { it.toDomain() } }
+        return response.mapCatching { searchItem -> searchItem.map { it.toDomain() } }
     }
 
     override suspend fun saveFestivalId(festivalId: Long) = festivalLocalDataSource.saveFestivalId(festivalId)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
@@ -16,7 +16,7 @@ interface FestivalService {
     suspend fun fetchOrganizationGeography(): Response<FestivalGeographyResponse>
 
     @GET("organizations/festivals/search")
-    suspend fun findUniversitiesByName(
+    suspend fun findFestivalsByKeyword(
         @Query("keyword") keyword: String,
     ): Response<List<UniversityResponse>>
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
@@ -1,6 +1,6 @@
 package com.daedan.festabook.data.service
 
-import com.daedan.festabook.data.model.response.UniversityResponse
+import com.daedan.festabook.data.model.response.FestivalSearchResponse
 import com.daedan.festabook.data.model.response.festival.FestivalGeographyResponse
 import com.daedan.festabook.data.model.response.festival.FestivalResponse
 import com.daedan.festabook.data.model.response.lostitem.LostGuideItemResponse
@@ -18,7 +18,7 @@ interface FestivalService {
     @GET("organizations/festivals/search")
     suspend fun findFestivalsByKeyword(
         @Query("keyword") keyword: String,
-    ): Response<List<UniversityResponse>>
+    ): Response<List<FestivalSearchResponse>>
 
     @GET("festivals/lost-item-guide")
     suspend fun fetchLostGuideItem(): Response<LostGuideItemResponse>

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalService.kt
@@ -15,9 +15,9 @@ interface FestivalService {
     @GET("festivals/geography")
     suspend fun fetchOrganizationGeography(): Response<FestivalGeographyResponse>
 
-    @GET("festivals/universities")
+    @GET("organizations/festivals/search")
     suspend fun findUniversitiesByName(
-        @Query("universityName") universityName: String,
+        @Query("keyword") keyword: String,
     ): Response<List<UniversityResponse>>
 
     @GET("festivals/lost-item-guide")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/model/FestivalSearchItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/model/FestivalSearchItem.kt
@@ -1,8 +1,8 @@
 package com.daedan.festabook.domain.model
 
-data class University(
+data class FestivalSearchItem(
     val festivalId: Long,
-    val universityName: String,
+    val organizationName: String,
     val festivalName: String,
     val startDate: String,
     val endDate: String,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/model/Organization.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/model/Organization.kt
@@ -2,6 +2,6 @@ package com.daedan.festabook.domain.model
 
 data class Organization(
     val id: Long,
-    val universityName: String,
+    val organizationName: String,
     val festival: Festival,
 )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
@@ -1,9 +1,9 @@
 package com.daedan.festabook.domain.repository
 
-import com.daedan.festabook.domain.model.University
+import com.daedan.festabook.domain.model.FestivalSearchItem
 
 interface ExploreRepository {
-    suspend fun search(query: String): Result<List<University>>
+    suspend fun search(query: String): Result<List<FestivalSearchItem>>
 
     suspend fun saveFestivalId(festivalId: Long)
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #19  

<br>

## 🛠️ 작업 내용

- 서버 api 변경에 따른 마이그레이션 작업을 진행했습니다. 
- university라는 도메인이 더이상 앱 내부에 존재하지 않도록, 전반적으로 네이밍을 수정했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 각자 `local.properties`도 변경된 주소로 업데이트해주세요!
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 검색 기능의 도메인 모델 및 저장소 구조를 개선하였습니다.
  * 검색 쿼리 매개변수 이름과 반환 데이터 모델을 명확하게 업데이트하였습니다.
  * API 엔드포인트와 내부 데이터 필드 이름을 일관성 있게 정렬하였습니다.

* **새로운 기능**
  * 축제 ID 조회 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->