### PR TITLE
[Test] PlaceDetailRepository, PlaceListRepository 테스트 코드 작성

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/place/PlaceDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/place/PlaceDataSourceTest.kt
@@ -1,0 +1,102 @@
+package com.daedan.festabook.data.datasource.remote.place
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.service.FestivalService
+import com.daedan.festabook.data.service.PlaceService
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaceDataSourceTest {
+    private lateinit var placeService: PlaceService
+    private lateinit var festivalService: FestivalService
+    private lateinit var placeDataSource: PlaceDataSource
+
+    @BeforeTest
+    fun setUp() {
+        placeService = mock()
+        festivalService = mock()
+        placeDataSource = PlaceDataSourceImpl(placeService, festivalService)
+    }
+
+    @Test
+    fun `플레이스 목록을 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeService.fetchPlaces() } returns FAKE_PLACES_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_PLACES_RESPONSE }
+            val result = placeDataSource.fetchPlaces()
+
+            // then
+            verifySuspend { placeService.fetchPlaces() }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `타임 태그를 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeService.fetchTimeTag() } returns FAKE_TIME_TAG_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_TIME_TAG_RESPONSE }
+            val result = placeDataSource.fetchTimeTag()
+
+            // then
+            verifySuspend { placeService.fetchTimeTag() }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `특정 플레이스의 상세 정보를 가져올 수 있다`() =
+        runTest {
+            // given
+            val placeId = 1L
+            everySuspend { placeService.fetchPlaceDetail(placeId) } returns FAKE_PLACE_DETAIL_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_PLACE_DETAIL_RESPONSE }
+            val result = placeDataSource.fetchPlaceDetail(placeId)
+
+            // then
+            verifySuspend { placeService.fetchPlaceDetail(placeId) }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `조직 지리 정보를 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { festivalService.fetchOrganizationGeography() } returns FAKE_FESTIVAL_GEOGRAPHY_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_FESTIVAL_GEOGRAPHY_RESPONSE }
+            val result = placeDataSource.fetchOrganizationGeography()
+
+            // then
+            verifySuspend { festivalService.fetchOrganizationGeography() }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `플레이스 지리 정보 목록을 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeService.fetchPlaceGeographies() } returns FAKE_PLACE_GEOGRAPHIES_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_PLACE_GEOGRAPHIES_RESPONSE }
+            val result = placeDataSource.fetchPlaceGeographies()
+
+            // then
+            verifySuspend { placeService.fetchPlaceGeographies() }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/place/TestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/place/TestFixture.kt
@@ -1,0 +1,188 @@
+package com.daedan.festabook.data.datasource.remote.place
+
+import com.daedan.festabook.data.model.response.festival.FestivalGeographyResponse
+import com.daedan.festabook.data.model.response.place.PlaceDetailResponse
+import com.daedan.festabook.data.model.response.place.PlaceGeographyResponse
+import com.daedan.festabook.data.model.response.place.PlaceResponse
+import com.daedan.festabook.data.model.response.place.TimeTagResponse
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+
+val FAKE_HTTP_RESPONSE =
+    mock<HttpResponse> {
+        every { status } returns HttpStatusCode.OK
+    }
+
+val FAKE_TIME_TAGS: List<TimeTagResponse> =
+    listOf(
+        TimeTagResponse(
+            name = "오전",
+            timeTagId = 1L,
+        ),
+        TimeTagResponse(
+            name = "오후",
+            timeTagId = 2L,
+        ),
+        TimeTagResponse(
+            name = "저녁",
+            timeTagId = 3L,
+        ),
+    )
+
+val FAKE_PLACE_DETAIL: PlaceDetailResponse =
+    PlaceDetailResponse(
+        id = 1L,
+        category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+        description = "테스트 부스 설명",
+        startTime = "10:00",
+        endTime = "18:00",
+        host = "주최자",
+        location = "A구역",
+        placeAnnouncements =
+            listOf(
+                PlaceDetailResponse.PlaceAnnouncement(
+                    id = 1L,
+                    title = "공지사항",
+                    content = "공지 내용",
+                    createdAt = "2024-01-01T10:00:00",
+                ),
+            ),
+        placeImages =
+            listOf(
+                PlaceDetailResponse.PlaceImage(
+                    id = 1L,
+                    imageUrl = "https://example.com/image.jpg",
+                    sequence = 1,
+                ),
+            ),
+        title = "테스트 부스",
+        timeTags =
+            listOf(
+                TimeTagResponse(
+                    name = "오전",
+                    timeTagId = 1L,
+                ),
+            ),
+    )
+
+val FAKE_PLACES: List<PlaceResponse> =
+    listOf(
+        PlaceResponse(
+            id = 1L,
+            title = "부스 1",
+            category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+            description = "부스 설명",
+            imageUrl = "https://example.com/booth1.jpg",
+            location = "A구역",
+            timeTags =
+                listOf(
+                    TimeTagResponse(name = "오전", timeTagId = 1L),
+                ),
+        ),
+        PlaceResponse(
+            id = 2L,
+            title = "푸드트럭 1",
+            category = PlaceGeographyResponse.PlaceCategory.FOOD_TRUCK,
+            description = "푸드트럭 설명",
+            imageUrl = "https://example.com/foodtruck1.jpg",
+            location = "B구역",
+            timeTags =
+                listOf(
+                    TimeTagResponse(name = "오후", timeTagId = 2L),
+                ),
+        ),
+    )
+
+val FAKE_FESTIVAL_GEOGRAPHY: FestivalGeographyResponse =
+    FestivalGeographyResponse(
+        zoom = 15,
+        centerCoordinate =
+            FestivalGeographyResponse.CenterCoordinate(
+                latitude = 37.5665,
+                longitude = 126.9780,
+            ),
+        polygonHoleBoundary =
+            listOf(
+                FestivalGeographyResponse.PolygonHoleBoundary(
+                    latitude = 37.5660,
+                    longitude = 126.9775,
+                ),
+                FestivalGeographyResponse.PolygonHoleBoundary(
+                    latitude = 37.5670,
+                    longitude = 126.9785,
+                ),
+            ),
+    )
+
+val FAKE_PLACE_GEOGRAPHIES: List<PlaceGeographyResponse> =
+    listOf(
+        PlaceGeographyResponse(
+            category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+            id = 1L,
+            markerCoordinate =
+                PlaceGeographyResponse.MarkerCoordinate(
+                    latitude = 37.5665,
+                    longitude = 126.9780,
+                ),
+            title = "부스 1",
+            timeTags =
+                listOf(
+                    TimeTagResponse(name = "오전", timeTagId = 1L),
+                ),
+        ),
+        PlaceGeographyResponse(
+            category = PlaceGeographyResponse.PlaceCategory.STAGE,
+            id = 2L,
+            markerCoordinate =
+                PlaceGeographyResponse.MarkerCoordinate(
+                    latitude = 37.5670,
+                    longitude = 126.9785,
+                ),
+            title = "메인 스테이지",
+            timeTags =
+                listOf(
+                    TimeTagResponse(name = "저녁", timeTagId = 3L),
+                ),
+        ),
+    )
+
+// ========== Mock Responses ==========
+
+@Suppress("UNCHECKED_CAST")
+val FAKE_TIME_TAG_RESPONSE: Response<List<TimeTagResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_TIME_TAGS,
+    ) as Response<List<TimeTagResponse>>
+
+@Suppress("UNCHECKED_CAST")
+val FAKE_PLACE_DETAIL_RESPONSE: Response<PlaceDetailResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_PLACE_DETAIL,
+    ) as Response<PlaceDetailResponse>
+
+@Suppress("UNCHECKED_CAST")
+val FAKE_PLACES_RESPONSE: Response<List<PlaceResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_PLACES,
+    ) as Response<List<PlaceResponse>>
+
+@Suppress("UNCHECKED_CAST")
+val FAKE_FESTIVAL_GEOGRAPHY_RESPONSE: Response<FestivalGeographyResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_FESTIVAL_GEOGRAPHY,
+    ) as Response<FestivalGeographyResponse>
+
+@Suppress("UNCHECKED_CAST")
+val FAKE_PLACE_GEOGRAPHIES_RESPONSE: Response<List<PlaceGeographyResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_PLACE_GEOGRAPHIES,
+    ) as Response<List<PlaceGeographyResponse>>

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/PlaceDetailRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/PlaceDetailRepositoryTest.kt
@@ -1,0 +1,102 @@
+package com.daedan.festabook.data.repository
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.place.PlaceDataSource
+import com.daedan.festabook.data.model.response.place.PlaceDetailResponse
+import com.daedan.festabook.data.model.response.place.PlaceGeographyResponse
+import com.daedan.festabook.data.model.response.place.TimeTagResponse
+import com.daedan.festabook.data.repository.fixture.fakePlaceDetailResponse
+import com.daedan.festabook.data.repository.fixture.fakePlaceDetailResponseWithImage
+import com.daedan.festabook.data.repository.fixture.fakePlaceDetailResponseWithNotice
+import com.daedan.festabook.domain.repository.PlaceDetailRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaceDetailRepositoryTest {
+    private lateinit var placeDataSource: PlaceDataSource
+    private lateinit var placeDetailRepository: PlaceDetailRepository
+
+    @BeforeTest
+    fun setUp() {
+        placeDataSource = mock()
+        placeDetailRepository = PlaceDetailRepositoryImpl(placeDataSource)
+    }
+
+    @Test
+    fun `플레이스 상세 정보를 성공적으로 가져올 수 있다`() =
+        runTest {
+            // given
+            val placeId = 1L
+            val expected = fakePlaceDetailResponse(placeId)
+
+            everySuspend { placeDataSource.fetchPlaceDetail(placeId) } returns ApiResult.Success(
+                expected
+            )
+
+            // when
+            val result = placeDetailRepository.getPlaceDetail(placeId)
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(placeId, actual.id)
+            assertEquals("테스트 장소", actual.place.title)
+            assertEquals("주최자", actual.host)
+        }
+
+    @Test
+    fun `플레이스 상세 정보의 공지사항을 시간 순으로 가져온다`() =
+        runTest {
+            // given
+            val placeId = 1L
+            val expected = fakePlaceDetailResponseWithNotice(placeId)
+
+            everySuspend { placeDataSource.fetchPlaceDetail(placeId) } returns ApiResult.Success(
+                expected
+            )
+
+            // when
+            val result = placeDetailRepository.getPlaceDetail(placeId)
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(2, actual.sortedNotices.size)
+            assertEquals("공지사항 제목2", actual.sortedNotices.first().title)
+            assertEquals("공지사항 제목1", actual.sortedNotices.last().title)
+        }
+
+    @Test
+    fun `플레이스 상세 정보의 이미지를 특정 순서로 가져온다`() =
+        runTest {
+            // given
+            val placeId = 1L
+            val expected = fakePlaceDetailResponseWithImage(placeId)
+
+            everySuspend { placeDataSource.fetchPlaceDetail(placeId) } returns ApiResult.Success(
+                expected
+            )
+
+            // when
+            val result = placeDetailRepository.getPlaceDetail(placeId)
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(2, actual.sortedImages.size)
+
+            assertEquals(
+                "https://example.com/image1.jpg",
+                actual.sortedImages.first().imageUrl
+            )
+            assertEquals(1, actual.sortedImages.first().sequence)
+            assertEquals(2, actual.sortedImages.last().sequence)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/PlaceListRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/PlaceListRepositoryTest.kt
@@ -1,0 +1,115 @@
+package com.daedan.festabook.data.repository
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.place.PlaceDataSource
+import com.daedan.festabook.data.model.response.place.TimeTagResponse
+import com.daedan.festabook.data.repository.fixture.FAKE_FESTIVAL_GEOGRAPHY_RESPONSE
+import com.daedan.festabook.data.repository.fixture.FAKE_PLACE_GEOGRAPHY_RESPONSE
+import com.daedan.festabook.data.repository.fixture.FAKE_PLACE_LIST_RESPONSE
+import com.daedan.festabook.domain.repository.PlaceListRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaceListRepositoryTest {
+    private lateinit var placeDataSource: PlaceDataSource
+    private lateinit var placeListRepository: PlaceListRepository
+
+    @BeforeTest
+    fun setUp() {
+        placeDataSource = mock()
+        placeListRepository = PlaceListRepositoryImpl(placeDataSource)
+    }
+
+    @Test
+    fun `타임 태그 목록을 가져올 수 있다`() =
+        runTest {
+            // given
+            val expected =
+                listOf(
+                    TimeTagResponse(name = "오전", timeTagId = 1L),
+                    TimeTagResponse(name = "오후", timeTagId = 2L),
+                    TimeTagResponse(name = "저녁", timeTagId = 3L),
+                )
+
+            everySuspend { placeDataSource.fetchTimeTag() } returns ApiResult.Success(expected)
+
+            // when
+            val result = placeListRepository.getTimeTags()
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(3, actual.size)
+            assertEquals("오전", actual.first().name)
+            assertEquals(1L, actual.first().timeTagId)
+        }
+
+    @Test
+    fun `플레이스 목록을 성공적으로 가져올 수 있다`() =
+        runTest {
+            // given
+            val expected = FAKE_PLACE_LIST_RESPONSE
+
+            everySuspend { placeDataSource.fetchPlaces() } returns ApiResult.Success(expected)
+
+            // when
+            val result = placeListRepository.getPlaces()
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(2, actual.size)
+            assertEquals("부스 1", actual.first().title)
+            assertEquals("A구역", actual.first().location)
+        }
+
+    @Test
+    fun `조직 지리 정보를 성공적으로 가져올 수 있다`() =
+        runTest {
+            // given
+            val expected = FAKE_FESTIVAL_GEOGRAPHY_RESPONSE
+
+            everySuspend { placeDataSource.fetchOrganizationGeography() } returns ApiResult.Success(
+                expected
+            )
+
+            // when
+            val result = placeListRepository.getOrganizationGeography()
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(15, actual.zoom)
+            assertEquals(37.5665, actual.initialCenter.latitude)
+            assertEquals(126.9780, actual.initialCenter.longitude)
+            assertEquals(2, actual.polygonHoleBoundary.size)
+        }
+
+    @Test
+    fun `플레이스 지리 정보 목록을 성공적으로 가져올 수 있다`() =
+        runTest {
+            // given
+            val expected = FAKE_PLACE_GEOGRAPHY_RESPONSE
+
+            everySuspend { placeDataSource.fetchPlaceGeographies() } returns ApiResult.Success(
+                expected
+            )
+
+            // when
+            val result = placeListRepository.getPlaceGeographies()
+
+            // then
+            assertTrue(result.isSuccess)
+            val actual = result.getOrThrow()
+            assertEquals(2, actual.size)
+            assertEquals("부스 1", actual.first().title)
+            assertEquals(37.5665, actual.first().markerCoordinate.latitude)
+            assertEquals(126.9780, actual.first().markerCoordinate.longitude)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/fixture/PlaceDetailRepositoryFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/fixture/PlaceDetailRepositoryFixture.kt
@@ -1,0 +1,87 @@
+package com.daedan.festabook.data.repository.fixture
+
+import com.daedan.festabook.data.model.response.place.PlaceDetailResponse
+import com.daedan.festabook.data.model.response.place.PlaceGeographyResponse
+import com.daedan.festabook.data.model.response.place.TimeTagResponse
+
+fun fakePlaceDetailResponse(placeId: Long) = PlaceDetailResponse(
+    id = placeId,
+    category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+    description = "테스트 장소 설명",
+    startTime = "10:00",
+    endTime = "18:00",
+    host = "주최자",
+    location = "테스트 위치",
+    placeAnnouncements = emptyList(),
+    placeImages =
+        listOf(
+            PlaceDetailResponse.PlaceImage(
+                id = 1L,
+                imageUrl = "https://example.com/image.jpg",
+                sequence = 1,
+            ),
+        ),
+    title = "테스트 장소",
+    timeTags =
+        listOf(
+            TimeTagResponse(
+                name = "오전",
+                timeTagId = 1L,
+            ),
+        ),
+)
+
+fun fakePlaceDetailResponseWithNotice(placeId: Long) =  PlaceDetailResponse(
+    id = placeId,
+    category = PlaceGeographyResponse.PlaceCategory.STAGE,
+    description = null,
+    startTime = null,
+    endTime = null,
+    host = null,
+    location = null,
+    placeAnnouncements =
+        listOf(
+            PlaceDetailResponse.PlaceAnnouncement(
+                id = 1L,
+                title = "공지사항 제목1",
+                content = "공지사항 내용1",
+                createdAt = "2024-01-01T10:00:00",
+            ),
+            PlaceDetailResponse.PlaceAnnouncement(
+                id = 2L,
+                title = "공지사항 제목2",
+                content = "공지사항 내용2",
+                createdAt = "2024-01-02T10:00:00",
+            )
+        ),
+    placeImages = emptyList(),
+    title = null,
+    timeTags = emptyList(),
+)
+
+fun fakePlaceDetailResponseWithImage(placeId: Long) =
+    PlaceDetailResponse(
+        id = placeId,
+        category = PlaceGeographyResponse.PlaceCategory.FOOD_TRUCK,
+        description = null,
+        startTime = null,
+        endTime = null,
+        host = null,
+        location = null,
+        placeAnnouncements = emptyList(),
+        placeImages =
+            listOf(
+                PlaceDetailResponse.PlaceImage(
+                    id = 1L,
+                    imageUrl = "https://example.com/image1.jpg",
+                    sequence = 1,
+                ),
+                PlaceDetailResponse.PlaceImage(
+                    id = 2L,
+                    imageUrl = "https://example.com/image2.jpg",
+                    sequence = 2,
+                ),
+            ),
+        title = null,
+        timeTags = emptyList(),
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/fixture/PlaceListRepositoryTestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/repository/fixture/PlaceListRepositoryTestFixture.kt
@@ -1,0 +1,84 @@
+package com.daedan.festabook.data.repository.fixture
+
+import com.daedan.festabook.data.model.response.festival.FestivalGeographyResponse
+import com.daedan.festabook.data.model.response.place.PlaceGeographyResponse
+import com.daedan.festabook.data.model.response.place.PlaceResponse
+import com.daedan.festabook.data.model.response.place.TimeTagResponse
+
+val FAKE_PLACE_LIST_RESPONSE = listOf(
+    PlaceResponse(
+        id = 1L,
+        title = "부스 1",
+        category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+        description = "부스 설명",
+        imageUrl = "https://example.com/booth1.jpg",
+        location = "A구역",
+        timeTags =
+            listOf(
+                TimeTagResponse(name = "오전", timeTagId = 1L),
+            ),
+    ),
+    PlaceResponse(
+        id = 2L,
+        title = "푸드트럭 1",
+        category = PlaceGeographyResponse.PlaceCategory.FOOD_TRUCK,
+        description = "푸드트럭 설명",
+        imageUrl = "https://example.com/foodtruck1.jpg",
+        location = "B구역",
+        timeTags =
+            listOf(
+                TimeTagResponse(name = "오후", timeTagId = 2L),
+            ),
+    ),
+)
+
+val FAKE_FESTIVAL_GEOGRAPHY_RESPONSE = FestivalGeographyResponse(
+    zoom = 15,
+    centerCoordinate =
+        FestivalGeographyResponse.CenterCoordinate(
+            latitude = 37.5665,
+            longitude = 126.9780,
+        ),
+    polygonHoleBoundary =
+        listOf(
+            FestivalGeographyResponse.PolygonHoleBoundary(
+                latitude = 37.5660,
+                longitude = 126.9775,
+            ),
+            FestivalGeographyResponse.PolygonHoleBoundary(
+                latitude = 37.5670,
+                longitude = 126.9785,
+            ),
+        ),
+)
+
+val FAKE_PLACE_GEOGRAPHY_RESPONSE = listOf(
+    PlaceGeographyResponse(
+        category = PlaceGeographyResponse.PlaceCategory.BOOTH,
+        id = 1L,
+        markerCoordinate =
+            PlaceGeographyResponse.MarkerCoordinate(
+                latitude = 37.5665,
+                longitude = 126.9780,
+            ),
+        title = "부스 1",
+        timeTags =
+            listOf(
+                TimeTagResponse(name = "오전", timeTagId = 1L),
+            ),
+    ),
+    PlaceGeographyResponse(
+        category = PlaceGeographyResponse.PlaceCategory.STAGE,
+        id = 2L,
+        markerCoordinate =
+            PlaceGeographyResponse.MarkerCoordinate(
+                latitude = 37.5670,
+                longitude = 126.9785,
+            ),
+        title = "메인 스테이지",
+        timeTags =
+            listOf(
+                TimeTagResponse(name = "저녁", timeTagId = 3L),
+            ),
+    ),
+)


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/22

<br>

## 🛠️ 작업 내용

- PlaceDetailRepositoryTest를 작성하였습니다
- PlaceListRepositoryTest를 작성하였습니다
- PlaceDatasourceTest를 작성하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 따로 복잡한 로직이 없어서 빠르게 작성했습니다 
- PlaceDetailRepository의 공지사항, 이미지 정렬 테스트도 간단하게 작성해봤습니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 장소 데이터 소스 및 저장소 기능에 대한 포괄적인 테스트 스위트 추가
  * 테스트 픽스처 및 모의 데이터 정의로 테스트 커버리지 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->