### PR TITLE
[Test] Datasource(Device, Faq, Notice, Festival, Lineup) 테스트 코드 작성

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/device/DeviceDataSourceTest.kt
@@ -1,0 +1,61 @@
+package com.daedan.festabook.data.datasource.remote.device
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.request.DeviceRegisterRequest
+import com.daedan.festabook.data.model.response.DeviceRegisterResponse
+import com.daedan.festabook.data.service.DeviceService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_DEVICE_REGISTER_RESPONSE: DeviceRegisterResponse =
+    DeviceRegisterResponse(id = 123)
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_DEVICE_REGISTER_HTTP_RESPONSE: Response<DeviceRegisterResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_DEVICE_REGISTER_RESPONSE,
+    ) as Response<DeviceRegisterResponse>
+
+class DeviceDataSourceTest {
+    private lateinit var deviceService: DeviceService
+    private lateinit var deviceRemoteDataSource: DeviceRemoteDataSource
+
+    @BeforeTest
+    fun setUp() {
+        deviceService = mock()
+        deviceRemoteDataSource = DeviceRemoteDataSourceImpl(deviceService)
+    }
+
+    @Test
+    fun `디바이스 식별자와 fcmToken으로 디바이스 등록을 할 수 있다`() =
+        runTest {
+            // given
+            val deviceIdentifier = "device-123"
+            val fcmToken = "fcm-abc"
+
+            val request =
+                DeviceRegisterRequest(
+                    deviceIdentifier = deviceIdentifier,
+                    fcmToken = fcmToken,
+                )
+
+            everySuspend { deviceService.registerDevice(request) } returns FAKE_DEVICE_REGISTER_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_DEVICE_REGISTER_HTTP_RESPONSE }
+            val result = deviceRemoteDataSource.registerDevice(deviceIdentifier, fcmToken)
+
+            // then
+            verifySuspend { deviceService.registerDevice(request) }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/faq/FAQDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/faq/FAQDataSourceTest.kt
@@ -1,0 +1,64 @@
+package com.daedan.festabook.data.datasource.remote.faq
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.response.faq.FAQResponse
+import com.daedan.festabook.data.service.FAQService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_FAQS: List<FAQResponse> =
+    listOf(
+        FAQResponse(
+            questionId = 1,
+            question = "Q1",
+            answer = "A1",
+            sequence = 1,
+        ),
+        FAQResponse(
+            questionId = 2,
+            question = "Q3",
+            answer = "A2",
+            sequence = 1,
+        ),
+    )
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_FAQ_HTTP_RESPONSE: Response<List<FAQResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_FAQS,
+    ) as Response<List<FAQResponse>>
+
+class FAQDataSourceTest {
+    private lateinit var faqService: FAQService
+    private lateinit var faqDataSource: FAQDataSource
+
+    @BeforeTest
+    fun setUp() {
+        faqService = mock()
+        faqDataSource = FAQDataSourceImpl(faqService)
+    }
+
+    @Test
+    fun `FAQ 전체 목록을 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { faqService.fetchAllFAQs() } returns FAKE_FAQ_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_FAQ_HTTP_RESPONSE }
+            val result = faqDataSource.fetchAllFAQs()
+
+            // then
+            verifySuspend { faqService.fetchAllFAQs() }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceTest.kt
@@ -1,0 +1,97 @@
+package com.daedan.festabook.data.datasource.remote.festival
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.request.FestivalNotificationRequest
+import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
+import com.daedan.festabook.data.service.FestivalNotificationService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_FESTIVAL_NOTIFICATION_RESPONSE =
+    FestivalNotificationResponse(
+        festivalNotificationId = 999L,
+    )
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_SAVE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE: Response<FestivalNotificationResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_FESTIVAL_NOTIFICATION_RESPONSE,
+    ) as Response<FestivalNotificationResponse>
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_DELETE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE: Response<Unit> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = Unit,
+    ) as Response<Unit>
+
+class FestivalNotificationRemoteDataSourceTest {
+    private lateinit var festivalNotificationService: FestivalNotificationService
+    private lateinit var dataSource: FestivalNotificationRemoteDataSource
+
+    @BeforeTest
+    fun setUp() {
+        festivalNotificationService = mock()
+        dataSource = FestivalNotificationRemoteDataSourceImpl(festivalNotificationService)
+    }
+
+    @Test
+    fun `축제 알림을 저장할 수 있다`() =
+        runTest {
+            // given
+            val festivalId = 10L
+            val deviceId = 20L
+
+            val request = FestivalNotificationRequest(deviceId = deviceId)
+
+            everySuspend {
+                festivalNotificationService.saveFestivalNotification(
+                    festivalId,
+                    request,
+                )
+            } returns FAKE_SAVE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_SAVE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE }
+            val result = dataSource.saveFestivalNotification(festivalId, deviceId)
+
+            // then
+            verifySuspend {
+                festivalNotificationService.saveFestivalNotification(
+                    festivalId,
+                    request,
+                )
+            }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `축제 알림을 삭제할 수 있다`() =
+        runTest {
+            // given
+            val festivalNotificationId = 999L
+
+            everySuspend {
+                festivalNotificationService.deleteFestivalNotification(festivalNotificationId)
+            } returns FAKE_DELETE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_DELETE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE }
+            val result = dataSource.deleteFestivalNotification(festivalNotificationId)
+
+            // then
+            verifySuspend {
+                festivalNotificationService.deleteFestivalNotification(festivalNotificationId)
+            }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
@@ -1,0 +1,117 @@
+package com.daedan.festabook.data.datasource.remote.festival
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.response.FestivalSearchResponse
+import com.daedan.festabook.data.model.response.festival.FestivalResponse
+import com.daedan.festabook.data.service.FestivalService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_FESTIVAL_RESPONSE =
+    FestivalResponse(
+        id = 1L,
+        organizationName = "대학교",
+        festivalImages = listOf(
+            FestivalResponse.FestivalImage(
+                id = 100L,
+                imageUrl = "https://image1.com",
+                sequence = 1,
+            ),
+            FestivalResponse.FestivalImage(
+                id = 101L,
+                imageUrl = "https://image2.com",
+                sequence = 2,
+            ),
+        ),
+        festivalName = "봄 축제",
+        startDate = "2026-04-01",
+        endDate = "2026-04-10",
+    )
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_FESTIVAL_HTTP_RESPONSE: Response<FestivalResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_FESTIVAL_RESPONSE,
+    ) as Response<FestivalResponse>
+
+private val FAKE_FESTIVAL_SEARCH_RESPONSES =
+    listOf(
+        FestivalSearchResponse(
+            festivalId = 1L,
+            organizationName = "대학교",
+            festivalName = "축제1",
+            startDate = "2024-04-01",
+            endDate = "2024-04-10",
+        ),
+        FestivalSearchResponse(
+            festivalId = 2L,
+            organizationName = "대학교2",
+            festivalName = "축제2",
+            startDate = "2024-06-01",
+            endDate = "2024-06-07",
+        ),
+    )
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_FESTIVAL_SEARCH_HTTP_RESPONSE: Response<List<FestivalSearchResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_FESTIVAL_SEARCH_RESPONSES,
+    ) as Response<List<FestivalSearchResponse>>
+
+class FestivalRemoteDataSourceTest {
+
+    private lateinit var festivalService: FestivalService
+    private lateinit var festivalRemoteDataSource: FestivalRemoteDataSource
+
+    @BeforeTest
+    fun setUp() {
+        festivalService = mock()
+        festivalRemoteDataSource = FestivalRemoteDataSourceImpl(festivalService)
+    }
+
+    @Test
+    fun `축제 데이터를 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { festivalService.fetchOrganization() } returns FAKE_FESTIVAL_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_FESTIVAL_HTTP_RESPONSE }
+            val result = festivalRemoteDataSource.fetchFestival()
+
+            // then
+            verifySuspend { festivalService.fetchOrganization() }
+            assertEquals(expected, result)
+        }
+
+    @Test
+    fun `키워드로 축제 검색 결과를 가져올 수 있다`() =
+        runTest {
+            // given
+            val keyword = "대학"
+
+            everySuspend {
+                festivalService.findFestivalsByKeyword(keyword)
+            } returns FAKE_FESTIVAL_SEARCH_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_FESTIVAL_SEARCH_HTTP_RESPONSE }
+            val result = festivalRemoteDataSource.findFestivalsByKeyword(keyword)
+
+            // then
+            verifySuspend {
+                festivalService.findFestivalsByKeyword(keyword)
+            }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/lineup/LineupDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/lineup/LineupDataSourceTest.kt
@@ -1,0 +1,65 @@
+package com.daedan.festabook.data.datasource.remote.lineup
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.response.lineup.LineupResponse
+import com.daedan.festabook.data.service.FestivalLineupService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_LINEUP: List<LineupResponse> =
+    listOf(
+        LineupResponse(
+            lineupId = 1,
+            imageUrl = "url",
+            name = "name",
+            performanceAt = "date"
+        ),
+        LineupResponse(
+            lineupId = 2,
+            imageUrl = "url",
+            name = "name",
+            performanceAt = "date"
+        ),
+    )
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_LINEUP_HTTP_RESPONSE: Response<List<LineupResponse>> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_LINEUP,
+    ) as Response<List<LineupResponse>>
+
+class LineupDataSourceTest {
+
+    private lateinit var festivalLineupService: FestivalLineupService
+    private lateinit var lineupDataSource: LineupDataSource
+
+    @BeforeTest
+    fun setUp() {
+        festivalLineupService = mock()
+        lineupDataSource = LineupDataSourceImpl(festivalLineupService)
+    }
+
+    @Test
+    fun `라인업 데이터를 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { festivalLineupService.fetchLineup() } returns FAKE_LINEUP_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_LINEUP_HTTP_RESPONSE }
+            val result = lineupDataSource.fetchLineup()
+
+            // then
+            verifySuspend { festivalLineupService.fetchLineup() }
+            assertEquals(expected, result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/notice/NoticeDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/notice/NoticeDataSourceTest.kt
@@ -1,0 +1,51 @@
+package com.daedan.festabook.data.datasource.remote.notice
+
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
+import com.daedan.festabook.data.model.response.notice.NoticeListResponse
+import com.daedan.festabook.data.service.NoticeService
+import de.jensklingenberg.ktorfit.Response
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val FAKE_NOTICE_LIST_RESPONSE =
+    NoticeListResponse
+
+@Suppress("UNCHECKED_CAST")
+private val FAKE_NOTICE_HTTP_RESPONSE: Response<NoticeListResponse> =
+    Response.success(
+        rawResponse = FAKE_HTTP_RESPONSE,
+        body = FAKE_NOTICE_LIST_RESPONSE,
+    ) as Response<NoticeListResponse>
+
+class NoticeDataSourceTest {
+    private lateinit var noticeService: NoticeService
+    private lateinit var noticeDataSource: NoticeDataSource
+
+    @BeforeTest
+    fun setUp() {
+        noticeService = mock()
+        noticeDataSource = NoticeDataSourceImpl(noticeService)
+    }
+
+    @Test
+    fun `공지사항 목록을 가져올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { noticeService.getNotices() } returns FAKE_NOTICE_HTTP_RESPONSE
+
+            // when
+            val expected = ApiResult.toApiResult { FAKE_NOTICE_HTTP_RESPONSE }
+            val result = noticeDataSource.fetchNotices()
+
+            // then
+            verifySuspend { noticeService.getNotices() }
+            assertEquals(expected, result)
+        }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #18 

<br>

## 🛠️ 작업 내용

- Datasource(Device, Faq, Notice, Festival, Lineup) 테스트 코드 작성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 축제 정보, 라인업, 공지사항, FAQ, 알림 등 주요 데이터 소스에 대한 단위 테스트 추가
  * 원격 데이터 소스의 동작 검증 및 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->