### PR TITLE
[Feat] placeMap/model 패키지 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@ captures/
 *.xcworkspace
 xcuserdata/
 
+
 # CocoaPods
 Pods/
+*.podspec
 
 ## iOS App packaging
 *.ipa

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.kotlinCocoapods) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -43,6 +43,8 @@ plugins {
 }
 
 kotlin {
+    compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+
     cocoapods {
         version = "2.0.1"
         summary = "festabook"
@@ -72,6 +74,7 @@ kotlin {
 
     sourceSets {
         androidMain.dependencies {
+            implementation(libs.map.sdk)
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.kotlinx.coroutines.android)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -39,9 +39,20 @@ plugins {
     alias(libs.plugins.buildkonfig)
     alias(libs.plugins.mokkery)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.kotlinCocoapods)
 }
 
 kotlin {
+    cocoapods {
+        version = "2.0.1"
+        summary = "festabook"
+        homepage = "https://landing.festabook.app/"
+        ios.deploymentTarget = "16.0"
+
+        pod("NMapsMap") {
+            version = "3.23.1"
+        }
+    }
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.android.kt
@@ -1,10 +1,10 @@
 package com.daedan.festabook.presentation.placeMap.platform
 
-import com.naver.maps.geometry.LatLng as NaverLatLng
+import com.naver.maps.geometry.LatLng as PlatformLatLng
 
 actual class LatLng actual constructor(
     latitude: Double,
     longitude: Double,
 ) {
-    val platform = NaverLatLng(latitude, longitude)
+    val platform = PlatformLatLng(latitude, longitude)
 }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.android.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import com.naver.maps.geometry.LatLng as NaverLatLng
+
+actual class LatLng actual constructor(
+    latitude: Double,
+    longitude: Double,
+) {
+    val platform = NaverLatLng(latitude, longitude)
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.android.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.getDrawableResourceBytes
 import org.jetbrains.compose.resources.getSystemResourceEnvironment
-import com.naver.maps.map.overlay.OverlayImage as NaverOverlayImage
+import com.naver.maps.map.overlay.OverlayImage as PlatformOverlayImage
 
 actual class OverlayImage private constructor(
-    val platform: NaverOverlayImage,
+    val platform: PlatformOverlayImage,
 ) {
     actual companion object {
         actual suspend fun create(resource: DrawableResource): OverlayImage =
@@ -18,7 +18,7 @@ actual class OverlayImage private constructor(
                 val imageByteArray = getDrawableResourceBytes(env, resource)
                 val imageBitmap = BitmapFactory.decodeByteArray(imageByteArray, 0, imageByteArray.size)
                 OverlayImage(
-                    platform = NaverOverlayImage.fromBitmap(imageBitmap),
+                    platform = PlatformOverlayImage.fromBitmap(imageBitmap),
                 )
             }
     }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.android.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import android.graphics.BitmapFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.getDrawableResourceBytes
+import org.jetbrains.compose.resources.getSystemResourceEnvironment
+import com.naver.maps.map.overlay.OverlayImage as NaverOverlayImage
+
+actual class OverlayImage private constructor(
+    val platform: NaverOverlayImage,
+) {
+    actual companion object {
+        actual suspend fun create(resource: DrawableResource): OverlayImage =
+            withContext(Dispatchers.IO) {
+                val env = getSystemResourceEnvironment()
+                val imageByteArray = getDrawableResourceBytes(env, resource)
+                val imageBitmap = BitmapFactory.decodeByteArray(imageByteArray, 0, imageByteArray.size)
+                OverlayImage(
+                    platform = NaverOverlayImage.fromBitmap(imageBitmap),
+                )
+            }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/mapManager/internal/OverlayImageManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/mapManager/internal/OverlayImageManager.kt
@@ -1,0 +1,28 @@
+package com.daedan.festabook.presentation.placeMap.mapManager.internal
+
+import com.daedan.festabook.presentation.placeMap.platform.OverlayImage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.DrawableResource
+
+/**
+ * OverlayImage를 flyweight 패턴으로 관리하기 위해 필요한 객체입니다
+ * 초기에 이미지 id를 받아 OverlayImage를 생성합니다
+ * 이후 getImage로 저장된 OverlayImage를 반환합니다
+ */
+class OverlayImageManager(
+    private val resources: List<DrawableResource>,
+    scope: CoroutineScope,
+) {
+    private val images = mutableMapOf<DrawableResource, OverlayImage>()
+
+    init {
+        scope.launch {
+            resources.forEach { drawable ->
+                images[drawable] = OverlayImage.create(drawable)
+            }
+        }
+    }
+
+    fun getImage(drawable: DrawableResource): OverlayImage? = images[drawable]
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/CoordinateUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/CoordinateUiModel.kt
@@ -1,0 +1,17 @@
+package com.daedan.festabook.presentation.placeMap.model
+
+import com.daedan.festabook.domain.model.Coordinate
+import com.daedan.festabook.presentation.placeMap.platform.LatLng
+
+data class CoordinateUiModel(
+    val latitude: Double,
+    val longitude: Double,
+)
+
+fun CoordinateUiModel.toLatLng() = LatLng(latitude, longitude)
+
+fun Coordinate.toUiModel() =
+    CoordinateUiModel(
+        latitude = latitude,
+        longitude = longitude,
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/InitialMapSettingUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/InitialMapSettingUiModel.kt
@@ -1,0 +1,16 @@
+package com.daedan.festabook.presentation.placeMap.model
+
+import com.daedan.festabook.domain.model.OrganizationGeography
+
+data class InitialMapSettingUiModel(
+    val zoom: Int,
+    val initialCenter: CoordinateUiModel,
+    val border: List<CoordinateUiModel>,
+)
+
+fun OrganizationGeography.toUiModel() =
+    InitialMapSettingUiModel(
+        zoom = zoom,
+        initialCenter = initialCenter.toUiModel(),
+        border = polygonHoleBoundary.map { it.toUiModel() },
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceCategoryUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceCategoryUiModel.kt
@@ -1,0 +1,198 @@
+package com.daedan.festabook.presentation.placeMap.model
+
+import androidx.compose.ui.graphics.Color
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.presentation.placeMap.mapManager.internal.OverlayImageManager
+import com.daedan.festabook.presentation.placeMap.platform.OverlayImage
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.ic_bar
+import festabookkmp.composeapp.generated.resources.ic_bar_selected
+import festabookkmp.composeapp.generated.resources.ic_booth
+import festabookkmp.composeapp.generated.resources.ic_booth_selected
+import festabookkmp.composeapp.generated.resources.ic_extra
+import festabookkmp.composeapp.generated.resources.ic_extra_selected
+import festabookkmp.composeapp.generated.resources.ic_food_truck
+import festabookkmp.composeapp.generated.resources.ic_food_truck_selected
+import festabookkmp.composeapp.generated.resources.ic_map_category_bar
+import festabookkmp.composeapp.generated.resources.ic_map_category_booth
+import festabookkmp.composeapp.generated.resources.ic_map_category_extra
+import festabookkmp.composeapp.generated.resources.ic_map_category_food_truck
+import festabookkmp.composeapp.generated.resources.ic_map_category_parking
+import festabookkmp.composeapp.generated.resources.ic_map_category_photo_booth
+import festabookkmp.composeapp.generated.resources.ic_map_category_primary
+import festabookkmp.composeapp.generated.resources.ic_map_category_smoking
+import festabookkmp.composeapp.generated.resources.ic_map_category_stage
+import festabookkmp.composeapp.generated.resources.ic_map_category_toilet
+import festabookkmp.composeapp.generated.resources.ic_map_category_trash
+import festabookkmp.composeapp.generated.resources.ic_parking
+import festabookkmp.composeapp.generated.resources.ic_parking_selected
+import festabookkmp.composeapp.generated.resources.ic_photo_booth
+import festabookkmp.composeapp.generated.resources.ic_photo_booth_selected
+import festabookkmp.composeapp.generated.resources.ic_primary
+import festabookkmp.composeapp.generated.resources.ic_primary_selected
+import festabookkmp.composeapp.generated.resources.ic_smoking_area
+import festabookkmp.composeapp.generated.resources.ic_smoking_area_selected
+import festabookkmp.composeapp.generated.resources.ic_stage
+import festabookkmp.composeapp.generated.resources.ic_stage_selected
+import festabookkmp.composeapp.generated.resources.ic_toilet
+import festabookkmp.composeapp.generated.resources.ic_toilet_selected
+import festabookkmp.composeapp.generated.resources.ic_trash
+import festabookkmp.composeapp.generated.resources.ic_trash_selected
+import festabookkmp.composeapp.generated.resources.map_category_bar
+import festabookkmp.composeapp.generated.resources.map_category_booth
+import festabookkmp.composeapp.generated.resources.map_category_extra
+import festabookkmp.composeapp.generated.resources.map_category_food_truck
+import festabookkmp.composeapp.generated.resources.map_category_parking
+import festabookkmp.composeapp.generated.resources.map_category_photo_booth
+import festabookkmp.composeapp.generated.resources.map_category_primary
+import festabookkmp.composeapp.generated.resources.map_category_smoking_area
+import festabookkmp.composeapp.generated.resources.map_category_stage
+import festabookkmp.composeapp.generated.resources.map_category_toilet
+import festabookkmp.composeapp.generated.resources.map_category_trash
+import org.jetbrains.compose.resources.DrawableResource
+
+enum class PlaceCategoryUiModel {
+    FOOD_TRUCK,
+    BOOTH,
+    BAR,
+
+    STAGE,
+    PHOTO_BOOTH,
+    PRIMARY,
+
+    EXTRA,
+    PARKING,
+    TOILET,
+
+    SMOKING_AREA,
+
+    TRASH_CAN,
+    ;
+
+    companion object {
+        val SECONDARY_CATEGORIES =
+            listOf(
+                TRASH_CAN,
+                TOILET,
+                SMOKING_AREA,
+                PARKING,
+                PRIMARY,
+                STAGE,
+                PHOTO_BOOTH,
+                EXTRA,
+            )
+    }
+}
+
+val PlaceCategoryUiModel.Companion.iconResources: List<DrawableResource>
+    get() {
+        val listOf =
+            listOf(
+                Res.drawable.ic_food_truck,
+                Res.drawable.ic_booth,
+                Res.drawable.ic_bar,
+                Res.drawable.ic_trash,
+                Res.drawable.ic_toilet,
+                Res.drawable.ic_smoking_area,
+                Res.drawable.ic_primary,
+                Res.drawable.ic_parking,
+                Res.drawable.ic_stage,
+                Res.drawable.ic_photo_booth,
+                Res.drawable.ic_extra,
+                Res.drawable.ic_food_truck_selected,
+                Res.drawable.ic_booth_selected,
+                Res.drawable.ic_bar_selected,
+                Res.drawable.ic_trash_selected,
+                Res.drawable.ic_toilet_selected,
+                Res.drawable.ic_smoking_area_selected,
+                Res.drawable.ic_primary_selected,
+                Res.drawable.ic_parking_selected,
+                Res.drawable.ic_stage_selected,
+                Res.drawable.ic_photo_booth_selected,
+                Res.drawable.ic_extra_selected,
+            )
+        return listOf
+    }
+
+fun PlaceCategoryUiModel.getLabelColor() =
+    when (this) {
+        PlaceCategoryUiModel.BOOTH -> Color(0xFF0094FF)
+        PlaceCategoryUiModel.FOOD_TRUCK -> Color(0xFF00AB40)
+        PlaceCategoryUiModel.BAR -> Color(0xFFFF9D00)
+        else -> Color.Unspecified
+    }
+
+fun OverlayImageManager.getNormalIcon(category: PlaceCategoryUiModel): OverlayImage? =
+    when (category) {
+        PlaceCategoryUiModel.BOOTH -> getImage(Res.drawable.ic_booth)
+        PlaceCategoryUiModel.FOOD_TRUCK -> getImage(Res.drawable.ic_food_truck)
+        PlaceCategoryUiModel.TOILET -> getImage(Res.drawable.ic_toilet)
+        PlaceCategoryUiModel.BAR -> getImage(Res.drawable.ic_bar)
+        PlaceCategoryUiModel.TRASH_CAN -> getImage(Res.drawable.ic_trash)
+        PlaceCategoryUiModel.SMOKING_AREA -> getImage(Res.drawable.ic_smoking_area)
+        PlaceCategoryUiModel.PRIMARY -> getImage(Res.drawable.ic_primary)
+        PlaceCategoryUiModel.PARKING -> getImage(Res.drawable.ic_parking)
+        PlaceCategoryUiModel.STAGE -> getImage(Res.drawable.ic_stage)
+        PlaceCategoryUiModel.PHOTO_BOOTH -> getImage(Res.drawable.ic_photo_booth)
+        PlaceCategoryUiModel.EXTRA -> getImage(Res.drawable.ic_extra)
+    }
+
+fun OverlayImageManager.getSelectedIcon(category: PlaceCategoryUiModel): OverlayImage? =
+    when (category) {
+        PlaceCategoryUiModel.BOOTH -> getImage(Res.drawable.ic_booth_selected)
+        PlaceCategoryUiModel.FOOD_TRUCK -> getImage(Res.drawable.ic_food_truck_selected)
+        PlaceCategoryUiModel.TOILET -> getImage(Res.drawable.ic_toilet_selected)
+        PlaceCategoryUiModel.BAR -> getImage(Res.drawable.ic_bar_selected)
+        PlaceCategoryUiModel.TRASH_CAN -> getImage(Res.drawable.ic_trash_selected)
+        PlaceCategoryUiModel.SMOKING_AREA -> getImage(Res.drawable.ic_smoking_area_selected)
+        PlaceCategoryUiModel.PRIMARY -> getImage(Res.drawable.ic_primary_selected)
+        PlaceCategoryUiModel.PARKING -> getImage(Res.drawable.ic_parking_selected)
+        PlaceCategoryUiModel.STAGE -> getImage(Res.drawable.ic_stage_selected)
+        PlaceCategoryUiModel.PHOTO_BOOTH -> getImage(Res.drawable.ic_photo_booth_selected)
+        PlaceCategoryUiModel.EXTRA -> getImage(Res.drawable.ic_extra_selected)
+    }
+
+fun PlaceCategoryUiModel.getIconId() =
+    when (this) {
+        PlaceCategoryUiModel.BOOTH -> Res.drawable.ic_map_category_booth
+        PlaceCategoryUiModel.FOOD_TRUCK -> Res.drawable.ic_map_category_food_truck
+        PlaceCategoryUiModel.TOILET -> Res.drawable.ic_map_category_toilet
+        PlaceCategoryUiModel.BAR -> Res.drawable.ic_map_category_bar
+        PlaceCategoryUiModel.TRASH_CAN -> Res.drawable.ic_map_category_trash
+        PlaceCategoryUiModel.SMOKING_AREA -> Res.drawable.ic_map_category_smoking
+        PlaceCategoryUiModel.PRIMARY -> Res.drawable.ic_map_category_primary
+        PlaceCategoryUiModel.PARKING -> Res.drawable.ic_map_category_parking
+        PlaceCategoryUiModel.STAGE -> Res.drawable.ic_map_category_stage
+        PlaceCategoryUiModel.PHOTO_BOOTH -> Res.drawable.ic_map_category_photo_booth
+        PlaceCategoryUiModel.EXTRA -> Res.drawable.ic_map_category_extra
+    }
+
+fun PlaceCategoryUiModel.getTextId() =
+    when (this) {
+        PlaceCategoryUiModel.BOOTH -> Res.string.map_category_booth
+        PlaceCategoryUiModel.FOOD_TRUCK -> Res.string.map_category_food_truck
+        PlaceCategoryUiModel.TOILET -> Res.string.map_category_toilet
+        PlaceCategoryUiModel.BAR -> Res.string.map_category_bar
+        PlaceCategoryUiModel.TRASH_CAN -> Res.string.map_category_trash
+        PlaceCategoryUiModel.SMOKING_AREA -> Res.string.map_category_smoking_area
+        PlaceCategoryUiModel.PRIMARY -> Res.string.map_category_primary
+        PlaceCategoryUiModel.PARKING -> Res.string.map_category_parking
+        PlaceCategoryUiModel.STAGE -> Res.string.map_category_stage
+        PlaceCategoryUiModel.PHOTO_BOOTH -> Res.string.map_category_photo_booth
+        PlaceCategoryUiModel.EXTRA -> Res.string.map_category_extra
+    }
+
+fun PlaceCategory.toUiModel() =
+    when (this) {
+        PlaceCategory.BOOTH -> PlaceCategoryUiModel.BOOTH
+        PlaceCategory.FOOD_TRUCK -> PlaceCategoryUiModel.FOOD_TRUCK
+        PlaceCategory.TOILET -> PlaceCategoryUiModel.TOILET
+        PlaceCategory.BAR -> PlaceCategoryUiModel.BAR
+        PlaceCategory.TRASH_CAN -> PlaceCategoryUiModel.TRASH_CAN
+        PlaceCategory.SMOKING_AREA -> PlaceCategoryUiModel.SMOKING_AREA
+        PlaceCategory.PARKING -> PlaceCategoryUiModel.PARKING
+        PlaceCategory.PRIMARY -> PlaceCategoryUiModel.PRIMARY
+        PlaceCategory.STAGE -> PlaceCategoryUiModel.STAGE
+        PlaceCategory.PHOTO_BOOTH -> PlaceCategoryUiModel.PHOTO_BOOTH
+        PlaceCategory.EXTRA -> PlaceCategoryUiModel.EXTRA
+    }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceCoordinateUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceCoordinateUiModel.kt
@@ -1,0 +1,20 @@
+package com.daedan.festabook.presentation.placeMap.model
+
+import com.daedan.festabook.domain.model.PlaceGeography
+
+data class PlaceCoordinateUiModel(
+    val placeId: Long,
+    val coordinate: CoordinateUiModel,
+    val category: PlaceCategoryUiModel,
+    val title: String,
+    val timeTagIds: List<Long>,
+)
+
+fun PlaceGeography.toUiModel() =
+    PlaceCoordinateUiModel(
+        placeId = id,
+        coordinate = markerCoordinate.toUiModel(),
+        category = category.toUiModel(),
+        title = title,
+        timeTagIds = timeTags.map { it.timeTagId },
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/model/PlaceUiModel.kt
@@ -1,0 +1,30 @@
+package com.daedan.festabook.presentation.placeMap.model
+
+import com.daedan.festabook.domain.model.Place
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlaceUiModel(
+    val id: Long,
+    val imageUrl: String?,
+    val category: PlaceCategoryUiModel,
+    val title: String?,
+    val description: String?,
+    val location: String?,
+    val isBookmarked: Boolean = false,
+    val timeTagId: List<Long>,
+)
+
+fun Place.toUiModel(): PlaceUiModel =
+    PlaceUiModel(
+        id = id,
+        imageUrl = imageUrl,
+        category = category.toUiModel(),
+        title = title,
+        description = description,
+        location = location,
+        timeTagId =
+            timeTags.map {
+                it.timeTagId
+            },
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+expect class LatLng(
+    latitude: Double,
+    longitude: Double,
+)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import org.jetbrains.compose.resources.DrawableResource
+
+expect class OverlayImage {
+    companion object {
+        suspend fun create(resource: DrawableResource): OverlayImage
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
@@ -19,18 +19,19 @@ private val FAKE_FESTIVAL_RESPONSE =
     FestivalResponse(
         id = 1L,
         organizationName = "대학교",
-        festivalImages = listOf(
-            FestivalResponse.FestivalImage(
-                id = 100L,
-                imageUrl = "https://image1.com",
-                sequence = 1,
+        festivalImages =
+            listOf(
+                FestivalResponse.FestivalImage(
+                    id = 100L,
+                    imageUrl = "https://image1.com",
+                    sequence = 1,
+                ),
+                FestivalResponse.FestivalImage(
+                    id = 101L,
+                    imageUrl = "https://image2.com",
+                    sequence = 2,
+                ),
             ),
-            FestivalResponse.FestivalImage(
-                id = 101L,
-                imageUrl = "https://image2.com",
-                sequence = 2,
-            ),
-        ),
         festivalName = "봄 축제",
         startDate = "2026-04-01",
         endDate = "2026-04-10",
@@ -69,7 +70,6 @@ private val FAKE_FESTIVAL_SEARCH_HTTP_RESPONSE: Response<List<FestivalSearchResp
     ) as Response<List<FestivalSearchResponse>>
 
 class FestivalRemoteDataSourceTest {
-
     private lateinit var festivalService: FestivalService
     private lateinit var festivalRemoteDataSource: FestivalRemoteDataSource
 

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/lineup/LineupDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/lineup/LineupDataSourceTest.kt
@@ -20,13 +20,13 @@ private val FAKE_LINEUP: List<LineupResponse> =
             lineupId = 1,
             imageUrl = "url",
             name = "name",
-            performanceAt = "date"
+            performanceAt = "date",
         ),
         LineupResponse(
             lineupId = 2,
             imageUrl = "url",
             name = "name",
-            performanceAt = "date"
+            performanceAt = "date",
         ),
     )
 
@@ -38,7 +38,6 @@ private val FAKE_LINEUP_HTTP_RESPONSE: Response<List<LineupResponse>> =
     ) as Response<List<LineupResponse>>
 
 class LineupDataSourceTest {
-
     private lateinit var festivalLineupService: FestivalLineupService
     private lateinit var lineupDataSource: LineupDataSource
 

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LatLng.ios.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import cocoapods.NMapsMap.NMGLatLng
+import kotlinx.cinterop.ExperimentalForeignApi
+
+@OptIn(ExperimentalForeignApi::class)
+actual class LatLng actual constructor(
+    latitude: Double,
+    longitude: Double,
+) {
+    val platform = NMGLatLng.latLngWithLat(latitude, longitude)
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/OverlayImage.ios.kt
@@ -1,0 +1,39 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import cocoapods.NMapsMap.NMFOverlayImage
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.getDrawableResourceBytes
+import org.jetbrains.compose.resources.getSystemResourceEnvironment
+import platform.Foundation.NSData
+import platform.Foundation.dataWithBytes
+import platform.UIKit.UIImage
+
+@OptIn(ExperimentalForeignApi::class)
+actual class OverlayImage private constructor(
+    val platform: NMFOverlayImage,
+) {
+    actual companion object {
+        actual suspend fun create(resource: DrawableResource): OverlayImage =
+            withContext(Dispatchers.IO) {
+                val env = getSystemResourceEnvironment()
+                val imageByteArray = getDrawableResourceBytes(env, resource)
+                val imageNSData =
+                    imageByteArray.usePinned { pinned ->
+                        NSData.dataWithBytes(
+                            bytes = pinned.addressOf(0),
+                            length = imageByteArray.size.toULong(),
+                        )
+                    }
+                val uiImage = UIImage(imageNSData)
+                OverlayImage(
+                    platform = NMFOverlayImage.overlayImageWithImage(uiImage),
+                )
+            }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ ktlint = "14.0.1"
 ktlintVersion = "0.5.0"
 mokkery = "3.2.0"
 landscapistCoil3 = "2.9.5"
+mapSdk = "3.22.1"
 
 [libraries]
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastorePreferences" }
@@ -59,7 +60,7 @@ landscapist-placeholder = { module = "com.github.skydoves:landscapist-placeholde
 landscapist-zoomable = { module = "com.github.skydoves:landscapist-zoomable", version.ref = "landscapistCoil3" }
 compottie = { module = "io.github.alexzhirkevich:compottie", version.ref = "compottie" }
 ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlintVersion" }
-
+map-sdk = { module = "com.naver.maps:map-sdk", version.ref = "mapSdk" }
 
 [plugins]
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlintVersi
 
 
 [plugins]
+kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,9 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
+        maven {
+            url = uri("https://repository.map.naver.com/archive/maven")
+        }
     }
 }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/30

<br>

## 🛠️ 작업 내용

- placeMap의 model 패키지를 마이그레이션 하였습니다

<br>

## 🙇🏻 중점 리뷰 요청

- NaverMap의 OverlayImage(android), NMFOverlayImage(iOS)을 연결지을 브릿지를 expect, actual class로 작성하였습니다
이유는 다음과 같습니다. 
1. expect class가 beta긴 하지만 jetbrain 팀에서 삭제할 생각은 없다고 명시함, 거의 stable
2. **interface 로 추상화할 경우 각 네이티브 단에서 불필요한 형변환 발생**
특히 NaverMap은 expect fun으로 만들 경우, 입 출력 타입이 모두 플랫폼별로 다르기 때문에, expect class를 사용하는 것이 가장 깔끔하다고 생각합니다. 


<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
