### PR TITLE
[Feat]  event, sideEffect, state 마이그레이션

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/FakePlaceDetailUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/FakePlaceDetailUiModel.kt
@@ -1,0 +1,8 @@
+package com.daedan.festabook.presentation.placeMap.intent
+
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+
+// 의존성 충돌 방지용 임시 model입니다
+data class FakePlaceDetailUiModel(
+    val place: PlaceUiModel,
+)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/FilterEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/FilterEvent.kt
@@ -1,0 +1,11 @@
+package com.daedan.festabook.presentation.placeMap.intent.event
+
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+
+sealed interface FilterEvent : PlaceMapEvent {
+    data class OnCategoryClick(
+        val categories: Set<PlaceCategoryUiModel>,
+    ) : FilterEvent
+
+    data object OnPlaceLoad : FilterEvent
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/MapControlEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/MapControlEvent.kt
@@ -1,0 +1,15 @@
+package com.daedan.festabook.presentation.placeMap.intent.event
+
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+
+sealed interface MapControlEvent : PlaceMapEvent {
+    data object OnMapReady : MapControlEvent
+
+    data object OnMapDrag : MapControlEvent
+
+    data class OnPlaceLoadFinish(
+        val places: List<PlaceUiModel>,
+    ) : MapControlEvent
+
+    data object OnBackToInitialPositionClick : MapControlEvent
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/PlaceMapEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/PlaceMapEvent.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook.presentation.placeMap.intent.event
+
+sealed interface PlaceMapEvent

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/SelectEvent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/event/SelectEvent.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.placeMap.intent.event
+
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.intent.FakePlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+
+sealed interface SelectEvent : PlaceMapEvent {
+    data class OnPlaceClick(
+        val placeId: Long,
+    ) : SelectEvent
+
+    data class OnPlacePreviewClick(
+        val place: LoadState<FakePlaceDetailUiModel>,
+    ) : SelectEvent
+
+    data object UnSelectPlace : SelectEvent
+
+    data class ExceededMaxLength(
+        val isExceededMaxLength: Boolean,
+    ) : SelectEvent
+
+    data class OnTimeTagClick(
+        val timeTag: TimeTag,
+    ) : SelectEvent
+
+    data object OnBackPress : SelectEvent
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/sideEffect/MapControlSideEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/sideEffect/MapControlSideEffect.kt
@@ -1,0 +1,34 @@
+package com.daedan.festabook.presentation.placeMap.intent.sideEffect
+
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.intent.FakePlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.model.InitialMapSettingUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCoordinateUiModel
+
+sealed interface MapControlSideEffect {
+    data object InitMap : MapControlSideEffect
+
+    data class InitMapManager(
+        val initialMapSetting: InitialMapSettingUiModel,
+    ) : MapControlSideEffect
+
+    data object BackToInitialPosition : MapControlSideEffect
+
+    data class SetMarkerByTimeTag(
+        val placeGeographies: List<PlaceCoordinateUiModel>,
+        val selectedTimeTag: LoadState<TimeTag>,
+        val isInitial: Boolean,
+    ) : MapControlSideEffect
+
+    data class FilterMapByCategory(
+        val selectedCategories: List<PlaceCategoryUiModel>,
+    ) : MapControlSideEffect
+
+    data class SelectMarker(
+        val placeDetail: LoadState<FakePlaceDetailUiModel>,
+    ) : MapControlSideEffect
+
+    data object UnselectMarker : MapControlSideEffect
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/sideEffect/PlaceMapSideEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/sideEffect/PlaceMapSideEffect.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.placeMap.intent.sideEffect
+
+import com.daedan.festabook.presentation.placeMap.intent.FakePlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+
+sealed interface PlaceMapSideEffect {
+    data class StartPlaceDetail(
+        val placeDetail: LoadState.Success<FakePlaceDetailUiModel>,
+    ) : PlaceMapSideEffect
+
+    data class PreloadImages(
+        val places: List<PlaceUiModel>,
+    ) : PlaceMapSideEffect
+
+    data class ShowErrorSnackBar(
+        val error: LoadState.Error,
+    ) : PlaceMapSideEffect
+
+    data class MenuItemReClicked(
+        val isPreviewVisible: Boolean,
+    ) : PlaceMapSideEffect
+
+    data class MapViewDrag(
+        val isPreviewVisible: Boolean,
+    ) : PlaceMapSideEffect
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/ListLoadState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/ListLoadState.kt
@@ -1,0 +1,19 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+
+sealed interface ListLoadState<out T> {
+    data object Loading : ListLoadState<Nothing>
+
+    data class Success<T>(
+        val value: T,
+    ) : ListLoadState<T>
+
+    data class PlaceLoaded(
+        val value: List<PlaceUiModel>,
+    ) : ListLoadState<List<PlaceUiModel>>
+
+    data class Error(
+        val throwable: Throwable,
+    ) : ListLoadState<Nothing>
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/LoadState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/LoadState.kt
@@ -1,0 +1,20 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import com.daedan.festabook.presentation.placeMap.intent.FakePlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+
+sealed interface LoadState<out T> {
+    data object Loading : LoadState<Nothing>
+
+    data object Empty : LoadState<Nothing>
+
+    data class Success<out T>(
+        val value: T,
+    ) : LoadState<T>
+
+    data class Error(
+        val throwable: Throwable,
+    ) : LoadState<Nothing>
+}
+
+val LoadState.Success<FakePlaceDetailUiModel>.isSecondary get() = value.place.category in PlaceCategoryUiModel.SECONDARY_CATEGORIES

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/MapDelegate.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/MapDelegate.kt
@@ -1,0 +1,30 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import com.daedan.festabook.presentation.placeMap.platform.NaverMap
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class MapDelegate {
+    var value: NaverMap? by mutableStateOf(null)
+        private set
+
+    fun initMap(map: NaverMap) {
+        value = map
+    }
+
+    suspend fun await(timeout: Duration = 3.seconds): NaverMap =
+        withTimeout(timeout) {
+            snapshotFlow { value }
+                .distinctUntilChanged()
+                .filterNotNull()
+                .first()
+        }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/MapManagerDelegate.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/MapManagerDelegate.kt
@@ -1,0 +1,15 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.daedan.festabook.presentation.placeMap.mapManager.MapManager
+
+class MapManagerDelegate {
+    var value: MapManager? by mutableStateOf(null)
+        private set
+
+    fun init(manager: MapManager) {
+        value = manager
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/PlaceMapUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/PlaceMapUiState.kt
@@ -1,0 +1,38 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.intent.FakePlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.model.InitialMapSettingUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCoordinateUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+
+data class PlaceMapUiState(
+    val initialMapSetting: LoadState<InitialMapSettingUiModel> = LoadState.Loading,
+    val placeGeographies: LoadState<List<PlaceCoordinateUiModel>> = LoadState.Loading,
+    val timeTags: LoadState<List<TimeTag>> = LoadState.Empty,
+    val selectedTimeTag: LoadState<TimeTag> = LoadState.Empty,
+    val selectedPlace: LoadState<FakePlaceDetailUiModel> = LoadState.Empty,
+    val places: ListLoadState<List<PlaceUiModel>> = ListLoadState.Loading,
+    val isExceededMaxLength: Boolean = false,
+    val selectedCategories: Set<PlaceCategoryUiModel> = emptySet(),
+    val initialCategories: List<PlaceCategoryUiModel> = PlaceCategoryUiModel.entries,
+) {
+    val isPlacePreviewVisible: Boolean =
+        (selectedPlace is LoadState.Success && !selectedPlace.isSecondary)
+
+    val isPlaceSecondaryPreviewVisible: Boolean =
+        (selectedPlace is LoadState.Success && selectedPlace.isSecondary)
+
+    val hasAnyError: LoadState<*>?
+        get() =
+            listOf(
+                initialMapSetting,
+                placeGeographies,
+                timeTags,
+                selectedTimeTag,
+                selectedPlace,
+                if (places is ListLoadState.Error) LoadState.Error(places.throwable) else LoadState.Empty,
+            ).filterIsInstance<LoadState.Error>()
+                .firstOrNull()
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/StateExt.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/StateExt.kt
@@ -1,0 +1,31 @@
+package com.daedan.festabook.presentation.placeMap.intent.state
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(FlowPreview::class)
+suspend inline fun <reified R> StateFlow<PlaceMapUiState>.await(
+    timeout: Duration = 3.seconds,
+    onTimeout: (Throwable) -> Unit = {},
+    crossinline selector: (PlaceMapUiState) -> Any?,
+): R =
+    try {
+        withTimeout(timeout) {
+            this@await
+                .map { selector(it) }
+                .distinctUntilChanged()
+                .filterIsInstance<R>()
+                .first()
+        }
+    } catch (e: TimeoutCancellationException) {
+        onTimeout(e)
+        throw e
+    }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/43

<br>

## 🛠️ 작업 내용

-  event, sideEffect, state 마이그레이션했습니다

<br>

## 🙇🏻 중점 리뷰 요청

- PlaceDetailModel 의존성을 Fake로 임시 대체하였습니다. 해당 부분은 Screen 마이그레이션 도중 필요할 때 마이그레이션 하겠습니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 장소 지도 기능의 상태 관리 및 이벤트 처리 체계 구축
  * 장소 선택, 카테고리 필터링, 시간대별 마커 표시 기능 지원
  * 장소 미리보기 및 오류 처리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->