### PR TITLE
[Feat] PlaceMap MVI 아키텍처 및 지도 관리 마이그레이션 (#44)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.android.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+import com.naver.maps.map.LocationSource as PlatformLocationSource
+
+actual class LocationSource(
+    val platform: PlatformLocationSource,
+)

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.android.kt
@@ -7,6 +7,15 @@ actual class NaverMap(
     val platformMap: PlatformMap,
 ) {
     val platformUiSettings = platformMap.uiSettings
+
+    private var _locationSource: LocationSource? = null
+    actual var locationSource: LocationSource?
+        get() = _locationSource
+        set(value) {
+            _locationSource = value
+            platformMap.locationSource = value?.platform
+        }
+
     actual var isIndoorEnabled: Boolean
         get() = platformMap.isIndoorEnabled
         set(value) {
@@ -37,6 +46,12 @@ actual class NaverMap(
         }
     }
 
+    actual fun addOnLocationChangeListener(listener: OnLocationChangeListener) {
+        platformMap.addOnLocationChangeListener { _ ->
+            listener.onLocationChange()
+        }
+    }
+
     actual fun setOnMapClickListener(onClick: (LatLng) -> Unit) {
         platformMap.setOnMapClickListener { pointF, latLng ->
             onClick(LatLng(latLng.latitude, latLng.longitude))
@@ -58,6 +73,10 @@ actual class NaverMap(
             reason: Int,
             animated: Boolean,
         )
+    }
+
+    actual fun interface OnLocationChangeListener {
+        actual fun onLocationChange()
     }
 
     actual class UiSettings(

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/mapManager/MapManagerBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/mapManager/MapManagerBindings.kt
@@ -1,0 +1,34 @@
+package com.daedan.festabook.di.mapManager
+
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.listener.MapClickListener
+import com.daedan.festabook.presentation.placeMap.listener.MapClickListenerImpl
+import com.daedan.festabook.presentation.placeMap.mapManager.internal.OverlayImageManager
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+import com.daedan.festabook.presentation.placeMap.model.iconResources
+import com.daedan.festabook.presentation.placeMap.platform.Marker
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+
+@BindingContainer
+@ContributesTo(PlaceMapScope::class)
+object MapManagerBindings {
+    @Provides
+    @SingleIn(PlaceMapScope::class)
+    fun provideMarkers(): MutableList<Marker> = mutableListOf()
+
+    @Provides
+    @SingleIn(PlaceMapScope::class)
+    fun provideOverlayImageManager(scope: CoroutineScope): OverlayImageManager =
+        OverlayImageManager(
+            resources = PlaceCategoryUiModel.iconResources,
+            scope = scope,
+        )
+
+    @Provides
+    @SingleIn(PlaceMapScope::class)
+    fun provideMapClickListener(viewModel: PlaceMapViewModel): MapClickListener = MapClickListenerImpl(viewModel)
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/mapManager/MapManagerGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/mapManager/MapManagerGraph.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.di.mapManager
+
+import androidx.compose.ui.unit.Density
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.mapManager.MapManager
+import com.daedan.festabook.presentation.placeMap.model.InitialMapSettingUiModel
+import com.daedan.festabook.presentation.placeMap.platform.NaverMap
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.CoroutineScope
+
+@DependencyGraph(PlaceMapScope::class)
+interface MapManagerGraph {
+    val mapManager: MapManager
+
+    @DependencyGraph.Factory
+    fun interface Factory {
+        fun create(
+            @Provides map: NaverMap,
+            @Provides settingUiModel: InitialMapSettingUiModel,
+            @Provides viewModel: PlaceMapViewModel,
+            @Provides initialPadding: Int,
+            @Provides scope: CoroutineScope,
+            @Provides density: Density,
+        ): MapManagerGraph
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/CachedPlaceByTimeTag.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/CachedPlaceByTimeTag.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.di.placeMapHandler
+
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class CachedPlaceByTimeTag

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/CachedPlaces.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/CachedPlaces.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.di.placeMapHandler
+
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class CachedPlaces

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/PlaceMapHandlerGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/PlaceMapHandlerGraph.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.di.placeMapHandler
+
+import com.daedan.festabook.presentation.placeMap.intent.handler.EventHandlerContext
+import com.daedan.festabook.presentation.placeMap.intent.handler.FilterEventHandler
+import com.daedan.festabook.presentation.placeMap.intent.handler.MapControlEventHandler
+import com.daedan.festabook.presentation.placeMap.intent.handler.SelectEventHandler
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Provides
+
+@GraphExtension(PlaceMapViewModelScope::class)
+interface PlaceMapHandlerGraph {
+    val filterEventHandler: FilterEventHandler
+    val selectEventHandler: SelectEventHandler
+    val mapControlEventHandler: MapControlEventHandler
+
+    @ContributesTo(AppScope::class)
+    @GraphExtension.Factory
+    interface Factory {
+        fun create(
+            @Provides context: EventHandlerContext,
+        ): PlaceMapHandlerGraph
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/PlaceMapViewModelScope.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/placeMapHandler/PlaceMapViewModelScope.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook.di.placeMapHandler
+
+abstract class PlaceMapViewModelScope private constructor()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/PlaceMapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/PlaceMapViewModel.kt
@@ -1,0 +1,195 @@
+package com.daedan.festabook.presentation.placeMap
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daedan.festabook.di.placeMapHandler.PlaceMapHandlerGraph
+import com.daedan.festabook.di.viewmodel.ViewModelKey
+import com.daedan.festabook.domain.repository.PlaceListRepository
+import com.daedan.festabook.presentation.placeMap.intent.event.FilterEvent
+import com.daedan.festabook.presentation.placeMap.intent.event.MapControlEvent
+import com.daedan.festabook.presentation.placeMap.intent.event.PlaceMapEvent
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.handler.EventHandlerContext
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.ListLoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.intent.state.await
+import com.daedan.festabook.presentation.placeMap.model.PlaceCoordinateUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@ContributesIntoMap(AppScope::class)
+@ViewModelKey(PlaceMapViewModel::class)
+@Inject
+class PlaceMapViewModel(
+    private val placeListRepository: PlaceListRepository,
+    handlerGraphFactory: PlaceMapHandlerGraph.Factory,
+) : ViewModel() {
+    private val cachedPlaces = MutableStateFlow(listOf<PlaceUiModel>())
+    private val cachedPlaceByTimeTag = MutableStateFlow<List<PlaceUiModel>>(emptyList())
+
+    private val _uiState = MutableStateFlow(PlaceMapUiState())
+    val uiState: StateFlow<PlaceMapUiState> = _uiState.asStateFlow()
+
+    private val _placeMapSideEffect = Channel<PlaceMapSideEffect>()
+    val placeMapSideEffect: Flow<PlaceMapSideEffect> = _placeMapSideEffect.receiveAsFlow()
+
+    private val _mapControlSideEffect = Channel<MapControlSideEffect>()
+    val mapControlSideEffect: Flow<MapControlSideEffect> = _mapControlSideEffect.receiveAsFlow()
+
+    private val handlerGraph =
+        handlerGraphFactory
+            .create(
+                EventHandlerContext(
+                    mapControlSideEffect = _mapControlSideEffect,
+                    placeMapSideEffect = _placeMapSideEffect,
+                    uiState = uiState,
+                    cachedPlaces = cachedPlaces,
+                    cachedPlaceByTimeTag = cachedPlaceByTimeTag,
+                    onUpdateCachedPlace = { cachedPlaceByTimeTag.tryEmit(it) },
+                    onUpdateState = { _uiState.update(it) },
+                    scope = viewModelScope,
+                ),
+            )
+
+    init {
+        loadOrganizationGeography()
+        loadTimeTags()
+        loadAllPlaces()
+        observeErrorEvent()
+    }
+
+    fun onPlaceMapEvent(event: PlaceMapEvent) {
+        when (event) {
+            is FilterEvent -> handlerGraph.filterEventHandler(event)
+            is MapControlEvent -> handlerGraph.mapControlEventHandler(event)
+            is SelectEvent -> handlerGraph.selectEventHandler(event)
+        }
+    }
+
+    fun onMenuItemReClicked() {
+        _placeMapSideEffect.trySend(
+            PlaceMapSideEffect.MenuItemReClicked(
+                uiState.value.isPlacePreviewVisible || uiState.value.isPlaceSecondaryPreviewVisible,
+            ),
+        )
+    }
+
+    private fun loadTimeTags() {
+        viewModelScope.launch {
+            placeListRepository
+                .getTimeTags()
+                .onSuccess { timeTags ->
+                    _uiState.update {
+                        it.copy(
+                            timeTags = LoadState.Success(timeTags),
+                        )
+                    }
+                }.onFailure {
+                    _uiState.update {
+                        it.copy(
+                            timeTags = LoadState.Empty,
+                        )
+                    }
+                }
+
+            // 기본 선택값
+            val timeTags = uiState.value.timeTags
+            val selectedTimeTag =
+                if (timeTags is LoadState.Success && timeTags.value.isNotEmpty()) {
+                    LoadState.Success(
+                        timeTags.value.first(),
+                    )
+                } else {
+                    LoadState.Empty
+                }
+            _uiState.update {
+                it.copy(selectedTimeTag = selectedTimeTag)
+            }
+
+            val placeGeographies =
+                uiState.await<LoadState.Success<List<PlaceCoordinateUiModel>>> { it.placeGeographies }
+            _mapControlSideEffect.send(
+                MapControlSideEffect.SetMarkerByTimeTag(
+                    placeGeographies = placeGeographies.value,
+                    selectedTimeTag = selectedTimeTag,
+                    isInitial = true,
+                ),
+            )
+        }
+    }
+
+    private fun loadOrganizationGeography() {
+        viewModelScope.launch {
+            placeListRepository.getOrganizationGeography().onSuccess { organizationGeography ->
+                _uiState.update {
+                    it.copy(initialMapSetting = LoadState.Success(organizationGeography.toUiModel()))
+                }
+            }
+
+            launch {
+                placeListRepository
+                    .getPlaceGeographies()
+                    .onSuccess { placeGeographies ->
+                        _uiState.update {
+                            it.copy(
+                                placeGeographies = LoadState.Success(placeGeographies.map { it.toUiModel() }),
+                            )
+                        }
+                    }.onFailure { item ->
+                        _uiState.update {
+                            it.copy(placeGeographies = LoadState.Error(item))
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun loadAllPlaces() {
+        viewModelScope.launch {
+            val result = placeListRepository.getPlaces()
+            result
+                .onSuccess { places ->
+                    val placeUiModels = places.map { it.toUiModel() }
+                    cachedPlaces.tryEmit(placeUiModels)
+                    _uiState.update { it.copy(places = ListLoadState.PlaceLoaded(placeUiModels)) }
+                }.onFailure { error ->
+                    _uiState.update { it.copy(places = ListLoadState.Error(error)) }
+                }
+        }
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun observeErrorEvent() {
+        viewModelScope.launch {
+            launch {
+                uiState
+                    .map { it.hasAnyError }
+                    .distinctUntilChanged()
+                    .filterIsInstance<LoadState.Error>()
+                    .debounce(1000)
+                    .collect {
+                        _placeMapSideEffect.send(PlaceMapSideEffect.ShowErrorSnackBar(it))
+                    }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/PlaceListBottomSheetState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/PlaceListBottomSheetState.kt
@@ -1,0 +1,75 @@
+package com.daedan.festabook.presentation.placeMap.component
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Velocity
+
+class PlaceListBottomSheetState(
+    val state: AnchoredDraggableState<PlaceListBottomSheetValue>,
+) {
+    val anchors get() = state.anchors
+    val settledValue get() = state.settledValue
+
+    val currentValue get() = state.currentValue
+    val offset get() = state.offset
+
+    suspend fun update(newState: PlaceListBottomSheetValue) {
+        state.animateTo(newState)
+    }
+
+    /**
+     anchoredState의 기본 settle() 동작은 거리 기반으로 동작합니다.
+     거리 기반 동작을, 상태 기반으로 동작하도록 변경하여, 미세한 드래그에도 바텀시트가 펼쳐지도록 합니다.
+     */
+    suspend fun settleImmediately(
+        available: Velocity,
+        animationSpec: AnimationSpec<Float> = spring(stiffness = Spring.StiffnessMediumLow),
+    ) {
+        val targetState =
+            if (available.y < 0) {
+                when (state.currentValue) {
+                    PlaceListBottomSheetValue.EXPANDED -> state.currentValue
+                    PlaceListBottomSheetValue.HALF_EXPANDED -> PlaceListBottomSheetValue.EXPANDED
+                    PlaceListBottomSheetValue.COLLAPSED -> PlaceListBottomSheetValue.HALF_EXPANDED
+                }
+            } else if (available.y > 0) {
+                when (state.currentValue) {
+                    PlaceListBottomSheetValue.EXPANDED -> PlaceListBottomSheetValue.HALF_EXPANDED
+                    PlaceListBottomSheetValue.HALF_EXPANDED -> PlaceListBottomSheetValue.COLLAPSED
+                    PlaceListBottomSheetValue.COLLAPSED -> state.currentValue
+                }
+            } else {
+                state.currentValue
+            }
+
+        state.animateTo(
+            targetValue = targetState,
+            animationSpec = animationSpec,
+        )
+    }
+}
+
+enum class PlaceListBottomSheetValue {
+    EXPANDED,
+    HALF_EXPANDED,
+    COLLAPSED,
+}
+
+@Composable
+fun rememberPlaceListBottomSheetState(
+    initialState: PlaceListBottomSheetValue = PlaceListBottomSheetValue.HALF_EXPANDED,
+): PlaceListBottomSheetState {
+    val anchoredState =
+        remember {
+            AnchoredDraggableState(initialValue = initialState)
+        }
+
+    return remember(anchoredState) {
+        PlaceListBottomSheetState(anchoredState)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/FakePlaceDetailUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/FakePlaceDetailUiModel.kt
@@ -1,8 +1,15 @@
 package com.daedan.festabook.presentation.placeMap.intent
 
+import com.daedan.festabook.domain.model.PlaceDetail
 import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
 
 // 의존성 충돌 방지용 임시 model입니다
 data class FakePlaceDetailUiModel(
     val place: PlaceUiModel,
 )
+
+fun PlaceDetail.toUiModel(): FakePlaceDetailUiModel =
+    FakePlaceDetailUiModel(
+        place = this.place.toUiModel(),
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/EventHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/EventHandler.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface EventHandler<ACTION, STATE> {
+    val uiState: StateFlow<STATE>
+    val onUpdateState: ((before: STATE) -> STATE) -> Unit
+
+    operator fun invoke(event: ACTION)
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/EventHandlerContext.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/EventHandlerContext.kt
@@ -1,0 +1,20 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.StateFlow
+
+data class EventHandlerContext(
+    val uiState: StateFlow<PlaceMapUiState>,
+    val onUpdateState: ((PlaceMapUiState) -> PlaceMapUiState) -> Unit,
+    val mapControlSideEffect: Channel<MapControlSideEffect>,
+    val scope: CoroutineScope,
+    val cachedPlaces: StateFlow<List<PlaceUiModel>>,
+    val cachedPlaceByTimeTag: StateFlow<List<PlaceUiModel>>,
+    val onUpdateCachedPlace: (List<PlaceUiModel>) -> Unit,
+    val placeMapSideEffect: Channel<PlaceMapSideEffect>,
+)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/FilterEventHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/FilterEventHandler.kt
@@ -1,0 +1,139 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import com.daedan.festabook.di.placeMapHandler.PlaceMapViewModelScope
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.intent.event.FilterEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.ListLoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.intent.state.await
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+@Inject
+@ContributesBinding(PlaceMapViewModelScope::class)
+class FilterEventHandler(
+    private val context: EventHandlerContext,
+//    private val logger: DefaultFirebaseLogger,
+) : EventHandler<FilterEvent, PlaceMapUiState> {
+    override val uiState: StateFlow<PlaceMapUiState> = context.uiState
+    override val onUpdateState = context.onUpdateState
+
+    override operator fun invoke(event: FilterEvent) {
+        when (event) {
+            is FilterEvent.OnCategoryClick -> {
+                context.scope.launch {
+                    uiState.await<ListLoadState.Success<PlaceUiModel>> { it.places }
+                    unselectPlace()
+                    updatePlacesByCategories(event.categories.toList())
+
+                    onUpdateState.invoke {
+                        it.copy(selectedCategories = event.categories)
+                    }
+
+                    context.mapControlSideEffect.send(MapControlSideEffect.FilterMapByCategory(event.categories.toList()))
+
+//                    logger.log(
+//                        PlaceCategoryClick(
+//                            baseLogData = logger.getBaseLogData(),
+//                            currentCategories = event.categories.joinToString(",") { it.toString() },
+//                        ),
+//                    )
+                }
+            }
+
+            is FilterEvent.OnPlaceLoad -> {
+                context.scope.launch {
+                    val selectedTimeTag =
+                        uiState
+                            .map { it.selectedTimeTag }
+                            .distinctUntilChanged()
+                            .first()
+
+                    when (selectedTimeTag) {
+                        is LoadState.Success -> {
+                            updatePlacesByTimeTag(selectedTimeTag.value.timeTagId)
+                        }
+
+                        is LoadState.Empty -> {
+                            updatePlacesByTimeTag(TimeTag.EMTPY_TIME_TAG_ID)
+                        }
+
+                        else -> {
+                            Unit
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun unselectPlace() {
+        onUpdateState.invoke { it.copy(selectedPlace = LoadState.Empty) }
+        context.mapControlSideEffect.trySend(MapControlSideEffect.UnselectMarker)
+    }
+
+    fun updatePlacesByTimeTag(timeTagId: Long) {
+        val filteredPlaces =
+            if (timeTagId == TimeTag.EMTPY_TIME_TAG_ID) {
+                context.cachedPlaces.value
+            } else {
+                filterPlacesByTimeTag(timeTagId)
+            }
+        onUpdateState.invoke {
+            it.copy(places = ListLoadState.Success(filteredPlaces))
+        }
+        context.onUpdateCachedPlace(filteredPlaces)
+    }
+
+    private fun updatePlacesByCategories(category: List<PlaceCategoryUiModel>) {
+        if (category.isEmpty()) {
+            clearPlacesFilter()
+            return
+        }
+
+        val secondaryCategories =
+            PlaceCategory.SECONDARY_CATEGORIES.map {
+                it.toUiModel()
+            }
+        val primaryCategoriesSelected = category.none { it in secondaryCategories }
+
+        if (!primaryCategoriesSelected) {
+            clearPlacesFilter()
+            return
+        }
+
+        val filteredPlaces =
+            context.cachedPlaceByTimeTag.value
+                .filter { place ->
+                    place.category in category
+                }
+        onUpdateState.invoke {
+            it.copy(places = ListLoadState.Success(filteredPlaces))
+        }
+    }
+
+    private fun filterPlacesByTimeTag(timeTagId: Long): List<PlaceUiModel> {
+        val filteredPlaces =
+            context.cachedPlaces.value.filter { place ->
+                place.timeTagId.contains(timeTagId)
+            }
+        return filteredPlaces
+    }
+
+    private fun clearPlacesFilter() {
+        onUpdateState.invoke {
+            it.copy(places = ListLoadState.Success(context.cachedPlaceByTimeTag.value))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlEventHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlEventHandler.kt
@@ -1,0 +1,68 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import com.daedan.festabook.di.placeMapHandler.PlaceMapViewModelScope
+import com.daedan.festabook.presentation.placeMap.intent.event.MapControlEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.intent.state.await
+import com.daedan.festabook.presentation.placeMap.model.InitialMapSettingUiModel
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@Inject
+@ContributesBinding(PlaceMapViewModelScope::class)
+class MapControlEventHandler(
+    private val context: EventHandlerContext,
+//    private val logger: DefaultFirebaseLogger,
+) : EventHandler<MapControlEvent, PlaceMapUiState> {
+    override val uiState: StateFlow<PlaceMapUiState> = context.uiState
+    override val onUpdateState = context.onUpdateState
+
+    override operator fun invoke(event: MapControlEvent) {
+        when (event) {
+            is MapControlEvent.OnMapReady -> {
+                context.scope.launch {
+                    context.mapControlSideEffect.send(MapControlSideEffect.InitMap)
+                    val setting =
+                        uiState.await<LoadState.Success<InitialMapSettingUiModel>> { it.initialMapSetting }
+                    context.mapControlSideEffect.send(MapControlSideEffect.InitMapManager(setting.value))
+                }
+            }
+
+            is MapControlEvent.OnPlaceLoadFinish -> {
+                context.scope.launch {
+                    context.placeMapSideEffect.send(
+                        PlaceMapSideEffect.PreloadImages(
+                            event.places,
+                        ),
+                    )
+                }
+            }
+
+            is MapControlEvent.OnBackToInitialPositionClick -> {
+                context.scope.launch {
+//                    logger.log(
+//                        PlaceBackToSchoolClick(
+//                            baseLogData = logger.getBaseLogData(),
+//                        ),
+//                    )
+                    context.mapControlSideEffect.send(MapControlSideEffect.BackToInitialPosition)
+                }
+            }
+
+            is MapControlEvent.OnMapDrag -> {
+                context.scope.launch {
+                    context.placeMapSideEffect.send(
+                        PlaceMapSideEffect.MapViewDrag(
+                            uiState.value.isPlacePreviewVisible || uiState.value.isPlaceSecondaryPreviewVisible,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlSideEffectHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlSideEffectHandler.kt
@@ -1,0 +1,133 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import androidx.compose.ui.unit.Density
+import com.daedan.festabook.di.mapManager.MapManagerGraph
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.MapDelegate
+import com.daedan.festabook.presentation.placeMap.intent.state.MapManagerDelegate
+import com.daedan.festabook.presentation.placeMap.mapManager.MapManager
+import com.daedan.festabook.presentation.placeMap.platform.LocationSource
+import dev.zacsweers.metro.createGraphFactory
+import kotlinx.coroutines.CoroutineScope
+
+class MapControlSideEffectHandler(
+    private val initialPadding: Int,
+//    private val logger: DefaultFirebaseLogger,
+    private val locationSource: LocationSource,
+    private val viewModel: PlaceMapViewModel,
+    private val mapDelegate: MapDelegate,
+    private val mapManagerDelegate: MapManagerDelegate,
+    private val scope: CoroutineScope,
+    private val density: Density,
+) : SideEffectHandler<MapControlSideEffect> {
+    private val uiState get() = viewModel.uiState.value
+    private val mapManager: MapManager? get() = mapManagerDelegate.value
+
+    override suspend operator fun invoke(event: MapControlSideEffect) {
+        when (event) {
+            is MapControlSideEffect.InitMap -> {
+                val naverMap = mapDelegate.await()
+                naverMap.addOnLocationChangeListener {
+//                    logger.log(
+//                        CurrentLocationChecked(
+//                            baseLogData = logger.getBaseLogData(),
+//                        ),
+//                    )
+                }
+                naverMap.locationSource = locationSource
+            }
+
+            is MapControlSideEffect.InitMapManager -> {
+                val naverMap = mapDelegate.await()
+                if (mapManager == null) {
+                    val graph =
+                        createGraphFactory<MapManagerGraph.Factory>().create(
+                            naverMap,
+                            event.initialMapSetting,
+                            viewModel,
+                            initialPadding,
+                            scope,
+                            density,
+                        )
+                    mapManagerDelegate.init(graph.mapManager)
+                    mapManager?.setupBackToInitialPosition { isExceededMaxLength ->
+                        viewModel.onPlaceMapEvent(
+                            SelectEvent.ExceededMaxLength(isExceededMaxLength),
+                        )
+                    }
+                }
+            }
+
+            is MapControlSideEffect.BackToInitialPosition -> {
+                mapManager?.moveToPosition()
+            }
+
+            is MapControlSideEffect.SetMarkerByTimeTag -> {
+                if (event.isInitial) {
+                    mapManager?.setupMarker(event.placeGeographies)
+                }
+
+                when (val selectedTimeTag = event.selectedTimeTag) {
+                    is LoadState.Success -> {
+                        mapManager?.filterMarkersByTimeTag(
+                            selectedTimeTag.value.timeTagId,
+                        )
+                    }
+
+                    is LoadState.Empty -> {
+                        mapManager?.filterMarkersByTimeTag(TimeTag.EMTPY_TIME_TAG_ID)
+                    }
+
+                    else -> {
+                        Unit
+                    }
+                }
+            }
+
+            is MapControlSideEffect.FilterMapByCategory -> {
+                val selectedCategories = event.selectedCategories
+                if (selectedCategories.isEmpty()) {
+                    mapManager?.clearFilter()
+                } else {
+                    mapManager?.filterMarkersByCategories(selectedCategories)
+                }
+            }
+
+            is MapControlSideEffect.SelectMarker -> {
+                when (val place = event.placeDetail) {
+                    is LoadState.Success -> {
+                        mapManager?.selectMarker(place.value.place.id)
+
+                        val currentTimeTag = uiState.selectedTimeTag
+                        val timeTagName =
+                            if (currentTimeTag is LoadState.Success) {
+                                currentTimeTag.value.name
+                            } else {
+                                "undefined"
+                            }
+//                        logger.log(
+//                            PlaceMarkerClick(
+//                                baseLogData = logger.getBaseLogData(),
+//                                placeId = place.value.place.id,
+//                                timeTagName = timeTagName,
+//                                category = place.value.place.category.name,
+//                            ),
+//                        )
+                    }
+
+                    else -> {
+                        Unit
+                    }
+                }
+            }
+
+            is MapControlSideEffect.UnselectMarker -> {
+                mapManager?.unselectMarker()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/PlaceMapSideEffectHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/PlaceMapSideEffectHandler.kt
@@ -1,0 +1,55 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.component.PlaceListBottomSheetState
+import com.daedan.festabook.presentation.placeMap.component.PlaceListBottomSheetValue
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.MapManagerDelegate
+import com.daedan.festabook.presentation.placeMap.mapManager.MapManager
+
+class PlaceMapSideEffectHandler(
+    private val mapManagerDelegate: MapManagerDelegate,
+    private val bottomSheetState: PlaceListBottomSheetState,
+    private val viewModel: PlaceMapViewModel,
+//    private val logger: DefaultFirebaseLogger,
+    // 안드로이드 종속적인 액션은 외부에서 주입
+    // TODO Compose로 전환 시, 콜백이 아닌 Compose State 주입
+    private val onPreloadImages: (PlaceMapSideEffect.PreloadImages) -> Unit,
+    private val onStartPlaceDetail: (PlaceMapSideEffect.StartPlaceDetail) -> Unit,
+    private val onShowErrorSnackBar: (PlaceMapSideEffect.ShowErrorSnackBar) -> Unit,
+) : SideEffectHandler<PlaceMapSideEffect> {
+    private val mapManager: MapManager? get() = mapManagerDelegate.value
+
+    override suspend operator fun invoke(event: PlaceMapSideEffect) {
+        when (event) {
+            is PlaceMapSideEffect.PreloadImages -> {
+                onPreloadImages(event)
+            }
+
+            is PlaceMapSideEffect.MenuItemReClicked -> {
+                mapManager?.moveToPosition()
+                if (!event.isPreviewVisible) return
+                viewModel.onPlaceMapEvent(SelectEvent.UnSelectPlace)
+//                logger.log(
+//                    PlaceMapButtonReClick(
+//                        baseLogData = logger.getBaseLogData(),
+//                    ),
+//                )
+            }
+
+            is PlaceMapSideEffect.StartPlaceDetail -> {
+                onStartPlaceDetail(event)
+            }
+
+            is PlaceMapSideEffect.ShowErrorSnackBar -> {
+                onShowErrorSnackBar(event)
+            }
+
+            is PlaceMapSideEffect.MapViewDrag -> {
+                if (event.isPreviewVisible) return
+                bottomSheetState.update(PlaceListBottomSheetValue.COLLAPSED)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandler.kt
@@ -1,0 +1,145 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+import com.daedan.festabook.di.placeMapHandler.PlaceMapViewModelScope
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.domain.repository.PlaceDetailRepository
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.intent.state.await
+import com.daedan.festabook.presentation.placeMap.intent.toUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceCoordinateUiModel
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@Inject
+@ContributesBinding(PlaceMapViewModelScope::class)
+class SelectEventHandler(
+    private val context: EventHandlerContext,
+    private val filterActionHandler: FilterEventHandler,
+//    private val logger: DefaultFirebaseLogger,
+    private val placeDetailRepository: PlaceDetailRepository,
+) : EventHandler<SelectEvent, PlaceMapUiState> {
+    override val uiState: StateFlow<PlaceMapUiState> = context.uiState
+    override val onUpdateState = context.onUpdateState
+
+    override operator fun invoke(event: SelectEvent) {
+        when (event) {
+            is SelectEvent.OnPlaceClick -> {
+                selectPlace(event.placeId)
+            }
+
+            is SelectEvent.UnSelectPlace -> {
+                unselectPlace()
+            }
+
+            is SelectEvent.ExceededMaxLength -> {
+                onUpdateState.invoke {
+                    it.copy(
+                        isExceededMaxLength = event.isExceededMaxLength,
+                    )
+                }
+            }
+
+            is SelectEvent.OnTimeTagClick -> {
+                onDaySelected(event.timeTag)
+                filterActionHandler.updatePlacesByTimeTag(event.timeTag.timeTagId)
+//                logger.log(
+//                    PlaceTimeTagSelected(
+//                        baseLogData = logger.getBaseLogData(),
+//                        timeTagName = event.timeTag.name,
+//                    ),
+//                )
+            }
+
+            is SelectEvent.OnPlacePreviewClick -> {
+                val selectedTimeTag = uiState.value.selectedTimeTag
+                val selectedPlace = event.place
+                if (selectedPlace is LoadState.Success) {
+                    context.scope.launch {
+                        context.placeMapSideEffect.send(PlaceMapSideEffect.StartPlaceDetail(event.place))
+//                        logger.log(
+//                            PlacePreviewClick(
+//                                baseLogData = logger.getBaseLogData(),
+//                                placeName =
+//                                    selectedPlace.value.place.title
+//                                        ?: "undefined",
+//                                timeTag =
+//                                    (selectedTimeTag as? LoadState.Success<TimeTag>)
+//                                        ?.value
+//                                        ?.name ?: "undefined",
+//                                category = selectedPlace.value.place.category.name,
+//                            ),
+//                        )
+                    }
+                }
+            }
+
+            is SelectEvent.OnBackPress -> {
+                unselectPlace()
+            }
+        }
+    }
+
+    private fun selectPlace(placeId: Long) {
+        context.scope.launch {
+            onUpdateState.invoke { it.copy(selectedPlace = LoadState.Loading) }
+            placeDetailRepository
+                .getPlaceDetail(placeId = placeId)
+                .onSuccess { item ->
+                    val newSelectedPlace = LoadState.Success(item.toUiModel())
+
+                    onUpdateState.invoke {
+                        it.copy(selectedPlace = newSelectedPlace)
+                    }
+                    context.mapControlSideEffect.send(
+                        MapControlSideEffect.SelectMarker(
+                            newSelectedPlace,
+                        ),
+                    )
+                    val selectedTimeTag = uiState.value.selectedTimeTag
+                    val timeTagName =
+                        if (selectedTimeTag is LoadState.Success) selectedTimeTag.value.name else "undefined"
+//                    logger.log(
+//                        PlaceItemClick(
+//                            baseLogData = logger.getBaseLogData(),
+//                            placeId = placeId,
+//                            timeTagName = timeTagName,
+//                            category = item.place.category.name,
+//                        ),
+//                    )
+                }.onFailure { item ->
+                    onUpdateState.invoke {
+                        it.copy(selectedPlace = LoadState.Error(item))
+                    }
+                }
+        }
+    }
+
+    private fun unselectPlace() {
+        onUpdateState.invoke { it.copy(selectedPlace = LoadState.Empty) }
+        context.mapControlSideEffect.trySend(MapControlSideEffect.UnselectMarker)
+    }
+
+    private fun onDaySelected(item: TimeTag) {
+        unselectPlace()
+        onUpdateState.invoke {
+            it.copy(selectedTimeTag = LoadState.Success(item))
+        }
+        context.scope.launch {
+            val placeGeographies =
+                uiState.await<LoadState.Success<List<PlaceCoordinateUiModel>>> { it.placeGeographies }
+            context.mapControlSideEffect.send(
+                MapControlSideEffect.SetMarkerByTimeTag(
+                    placeGeographies = placeGeographies.value,
+                    selectedTimeTag = LoadState.Success(item),
+                    isInitial = false,
+                ),
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SideEffectHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SideEffectHandler.kt
@@ -1,0 +1,5 @@
+package com.daedan.festabook.presentation.placeMap.intent.handler
+
+interface SideEffectHandler<EVENT> {
+    suspend operator fun invoke(event: EVENT)
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/listener/MapClickListenerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/listener/MapClickListenerImpl.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.presentation.placeMap.listener
+
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+
+class MapClickListenerImpl(
+    private val viewModel: PlaceMapViewModel,
+) : MapClickListener {
+    override fun onMarkerListener(
+        placeId: Long,
+        category: PlaceCategoryUiModel,
+    ): Boolean {
+//        Timber.d("Marker CLick : placeID: $placeId categoty: $category")
+        viewModel.onPlaceMapEvent(
+            SelectEvent.OnPlaceClick(placeId),
+        )
+        return true
+    }
+
+    override fun onMapClickListener() {
+//        Timber.d("Map CLick")
+        viewModel.onPlaceMapEvent(SelectEvent.UnSelectPlace)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+expect class LocationSource

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.kt
@@ -8,9 +8,13 @@ expect class NaverMap {
     val uiSettings: UiSettings
     val cameraPosition: CameraPosition
 
+    var locationSource: LocationSource?
+
     fun moveCamera(cameraUpdate: CameraUpdate)
 
     fun addOnCameraChangeListener(listener: OnCameraChangeListener)
+
+    fun addOnLocationChangeListener(listener: OnLocationChangeListener)
 
     fun setOnMapClickListener(onClick: (LatLng) -> Unit)
 
@@ -27,6 +31,10 @@ expect class NaverMap {
             reason: Int,
             animated: Boolean,
         )
+    }
+
+    fun interface OnLocationChangeListener {
+        fun onLocationChange()
     }
 
     class UiSettings {

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/LocationSource.ios.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook.presentation.placeMap.platform
+
+actual class LocationSource

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/platform/NaverMap.ios.kt
@@ -1,5 +1,7 @@
 package com.daedan.festabook.presentation.placeMap.platform
 
+import cocoapods.NMapsMap.NMFLocationManager
+import cocoapods.NMapsMap.NMFLocationManagerDelegateProtocol
 import cocoapods.NMapsMap.NMFMapView
 import cocoapods.NMapsMap.NMFMapViewCameraDelegateProtocol
 import cocoapods.NMapsMap.NMFMapViewTouchDelegateProtocol
@@ -16,6 +18,13 @@ import platform.darwin.NSObject
 actual class NaverMap(
     val platformMap: NMFNaverMapView,
 ) {
+    private var _locationSource: LocationSource? = null
+    actual var locationSource: LocationSource?
+        get() = _locationSource
+        set(value) {
+            _locationSource = value
+        }
+
     actual val cameraPosition: CameraPosition
         get() = CameraPosition(platformMap.mapView.cameraPosition)
 
@@ -32,6 +41,19 @@ actual class NaverMap(
                     animated: Boolean,
                 ) {
                     listener.onCameraChange(cameraDidChangeByReason.toInt(), animated)
+                }
+            },
+        )
+    }
+
+    actual fun addOnLocationChangeListener(listener: OnLocationChangeListener) {
+        NMFLocationManager.sharedInstance()?.addDelegate(
+            object : NSObject(), NMFLocationManagerDelegateProtocol {
+                override fun locationManager(
+                    locationManager: NMFLocationManager?,
+                    didUpdateLocations: List<*>?,
+                ) {
+                    listener.onLocationChange()
                 }
             },
         )
@@ -88,6 +110,10 @@ actual class NaverMap(
             reason: Int,
             animated: Boolean,
         )
+    }
+
+    actual fun interface OnLocationChangeListener {
+        actual fun onLocationChange()
     }
 
     actual class UiSettings(


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #44, #47 #48 

<br>

## 🛠️ 작업 내용

### 1. KMP expect/actual 지도 플랫폼 브릿지 완성 (#42)
- `CameraUpdate`, `CameraPosition`, `CameraAnimation` expect/actual 구현 (Android: Naver Maps SDK, iOS: NMapsMap CocoaPods)
- `Marker` expect class에 `tag`, `position`, `icon`, `captionText`, `isVisible`, `setOnClickListener` 속성 추가
- iOS `Marker.ios.kt`: 역방향 복원이 어려운 속성(`_tag`, `_map`, `_icon`)을 backing field로 관리
- `PolygonOverlay.android.kt`: `commonMap` → `_map` 변수명 일관성 개선

### 2. MapManager 구현 (#42)
- `MapMarkerManagerImpl`: 마커 생성/배치, 선택/해제 시 아이콘·캡션·Z-Index 변경, 카메라 이동 로직
- `MapFilterManagerImpl`: 카테고리(`PlaceCategoryUiModel`) 및 타임태그(`TimeTag`) 기반 마커 필터링
- `MapCameraManagerImpl`: 카메라 이동, 줌, 애니메이션 제어
- `PlaceMapScope` 추가 및 Metro DI 바인딩 설정

### 3. PlaceMap MVI 인텐트 정의 (#45)
- `PlaceMapEvent` 계층: `FilterEvent`, `SelectEvent`, `MapControlEvent`
- `PlaceMapSideEffect` / `MapControlSideEffect`: UI 흐름 및 지도 뷰 제어 사이드 이펙트
- `PlaceMapUiState`: 지도 설정, 좌표, 선택 장소, 카테고리 등 전체 UI 상태 데이터 클래스
- `LoadState`, `ListLoadState`: 데이터 로드 상태 sealed interface
- `MapDelegate`, `MapManagerDelegate`: NaverMap/MapManager 인스턴스 비동기 대기 델리게이트
- `StateExt.kt`: `StateFlow<PlaceMapUiState>` await 확장 함수

### 4. MVI 이벤트 핸들러 구현
- `EventHandlerContext`: 핸들러 간 상태 공유 및 SideEffect 전달 공통 컨텍스트
- `FilterEventHandler`: 카테고리/타임태그 기반 장소 필터링
- `SelectEventHandler`: 장소 클릭·상세 조회·시간대 선택·뒤로가기 처리
- `MapControlEventHandler`: 지도 초기화·초기 위치 복귀·드래그 감지·이미지 프리로딩
- `PlaceMapHandlerGraph`: Metro DI로 각 핸들러 의존성 주입

### 5. PlaceMapViewModel 구현
- `PlaceMapViewModel`: `PlaceMapHandlerGraph`를 통해 복잡한 비즈니스 로직 위임
- `placeListRepository`를 통한 조직 지리정보·장소 좌표·시간태그 데이터 로드
- `debounce`로 에러 상태 관찰 후 스낵바 표시
- `onMenuItemReClicked`: 메뉴 재클릭 시 프리뷰 상태에 따른 사이드 이펙트 처리

### 6. DI 설정 및 클릭 리스너
- `MapManagerBindings.kt`: `Marker` 리스트, `OverlayImageManager`, `MapClickListener` Metro 바인딩
- `MapManagerGraph.kt`: `NaverMap`, `PlaceMapViewModel`을 받아 `MapManager` 생성 팩토리
- `MapClickListenerImpl`: 마커 클릭 → `SelectEvent.OnPlaceClick`, 빈 공간 클릭 → `SelectEvent.UnSelectPlace`

<br>

## 🙇🏻 중점 리뷰 요청

- **`MapFilterManagerImpl` 필터링 로직**: `filterMarkersByCategories`에서 `&&`/`||` 조건 혼용 구간의 우선순위가 의도한 대로인지, early return 경로에서 `selectedMarker` 등 상태 초기화가 누락된 부분이 없는지 확인 부탁드립니다.

- **`EventHandlerContext` 설계**: 핸들러 간 상태를 단일 컨텍스트로 공유하는 방식이 적절한지, StateFlow 업데이트 충돌 가능성이 있는지 검토 부탁드립니다.

- **`MapDelegate.await()` 비동기 처리**: `NaverMap` 인스턴스를 `CompletableDeferred`로 대기하는 패턴에서 타임아웃·취소 처리가 충분한지 확인 부탁드립니다.

- **iOS `Marker.ios.kt` backing field 관리**: `_tag`, `_map`, `_icon` backing field를 사용해 Obj-C 역방향 복원을 우회하는 방식에서 메모리 누수나 불일치 상황이 없는지 검토 부탁드립니다.

- **`PlaceMapHandlerGraph` DI 구성**: `PlaceMapViewModelScope`와 `CachedPlaces`, `CachedPlaceByTimeTag` 한정자 설계가 Metro DI 컨벤션에 맞는지 확인 부탁드립니다.

<br>

## 📸 이미지 첨부 (Optional)

생략

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 장소 지도 화면 추가
  * 마커 클릭으로 장소 선택 및 상세 정보 보기
  * 카테고리 및 시간대별 필터링으로 표시 장소 제어
  * 지도 드래그·줌·초기 위치 복귀 등 맵 컨트롤
  * 선택된 장소 미리보기 및 선택 취소
  * 장소 목록 바텀시트로 상태 기반 전환 및 애니메이션 지원
  * 위치 변경 이벤트 수신으로 실시간 위치 연동 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->