### PR TITLE
[Chore] Slack 리뷰 리마인더 워크플로우에 pull-requests 권한 추가

### DIFF
--- a/.github/workflows/common-slack-review-reminder.yml
+++ b/.github/workflows/common-slack-review-reminder.yml
@@ -6,7 +6,11 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+
 jobs:
+
   remind:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #49
<br>

## 🛠️ 작업 내용

- Slack 리뷰 리마인더 워크플로우가 Pull Request 정보를 읽을 수 있도록 `pull-requests: read` 권한을 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트에는 최종 사용자에게 영향을 주는 변경 사항이 없습니다. 내부 개발 인프라 구성에 대한 유지보수 작업이 수행되었습니다.

* **Chores**
  * GitHub Actions 워크플로 권한 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->