### PR TITLE
[Build]: iOS CocoaPods 설정 및 네이버 지도 SDK 연동

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,7 +26,10 @@ private val baseImageUrl =
     getLocalProperty("IMAGE_BASE_URL") ?: error("IMAGE_BASE_URL가 local.properties에 없음")
 
 private val naverMapStyleId =
-    getLocalProperty("NAVER_MAP_STYLE_ID") ?: error("NAVER_MAP_STYLE_ID local.properties에 없음")
+    getLocalProperty("NAVER_MAP_STYLE_ID") ?: error("NAVER_MAP_STYLE_ID가 local.properties에 없음")
+
+private val naverMapClientId =
+    getLocalProperty("NAVER_MAP_CLIENT_ID") ?: error("NAVER_MAP_CLIENT_ID가 local.properties에 없음")
 
 
 plugins {
@@ -120,6 +123,7 @@ buildkonfig {
 
     defaultConfigs {
         buildConfigField(STRING, "NAVER_MAP_STYLE_ID", naverMapStyleId)
+        buildConfigField(STRING, "NAVER_MAP_CLIENT_ID", naverMapClientId)
         buildConfigField(STRING, "FESTABOOK_URL", baseUrl)
         buildConfigField(STRING, "FESTABOOK_IMAGE_URL", baseImageUrl)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.caching=true
 #Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+
+kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
+kotlin.native.cacheKind.iosSimulatorArm64=none

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -1,0 +1,13 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+platform :ios, '16.0'
+
+target 'iosApp' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for iosApp
+  pod 'NMapsMap'
+
+end

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - NMapsGeometry (1.0.2)
+  - NMapsMap (3.23.1):
+    - NMapsGeometry
+
+DEPENDENCIES:
+  - NMapsMap
+
+SPEC REPOS:
+  trunk:
+    - NMapsGeometry
+    - NMapsMap
+
+SPEC CHECKSUMS:
+  NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
+  NMapsMap: b4272a60dcbb8bccb206c632a133cae27a160031
+
+PODFILE CHECKSUM: ff32aad0fb2ca36057f4e02d63988ef75ac8eeb7
+
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## #️⃣ 이슈 번호
> https://github.com/festabook/kotlin-multiplatform/issues/53

<br>

## 🛠️ 작업 내용

- xcode에서 빌드가 되도록 gradle 설정을 변경했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

### iosApp에 Podfile을 생성한 이유
1. 이론상 isStatic = true로 설정하게 된다면 composeApp에서 사용한 의존성을 하나의 모듈 바이너리에 다 때려박는 것으로 알고있습니다.
2. 하지만 kotlin interop에선 objective-c의 .h 파일만 변환하는 것으로 추정됩니다. 
이유: gradle(kotlin) 단에서는 링킹이 성공합니다 (./gradlew  composeApp:linkDebugFrameworkIosSimulatorArm64 task 성공)

하지만 xcode에서 빌드할 때 다음과 참조 에러가 발생합니다. 


Showing Recent Messages
Undefined symbol: _OBJC_CLASS_$_NMFCameraUpdate

Undefined symbol: _OBJC_CLASS_$_NMFLocationManager

Undefined symbol: _OBJC_CLASS_$_NMFMarker

Undefined symbol: _OBJC_CLASS_$_NMFOverlayImage

Undefined symbol: _OBJC_CLASS_$_NMFPolygonOverlay

Undefined symbol: _OBJC_CLASS_$_NMGLatLng

Undefined symbol: _OBJC_CLASS_$_NMGLineString

Undefined symbol: _OBJC_CLASS_$_NMGPolygon



<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * iOS 빌드 설정 업데이트 및 최소 플랫폼 버전을 iOS 16.0으로 설정
  * 빌드 구성에 새로운 클라이언트 설정 필드 추가
  * Gradle 속성 및 iOS 의존성 구성 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->