### PR TITLE
[Chore] CodeRabbit, Claude yml main에 추가 (#68)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [ opened, synchronize, ready_for_review, reopened ]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,7 +38,41 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          
+          GitHub PR을 원격에서 리뷰하고 꼭 라인별 코멘트를 게시해 주세요. 
+          이 PR의 composeApp/commonMain/** 에 해당하는 코드는 Compose Multiplatform 관점에서 리뷰해 주세요.
+          특히 다음을 확인해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - 플랫폼(Android/iOS/Desktop) 의존 API가 commonMain에 직접 사용되지 않았는지
+          - expect / actual 분리가 필요한 코드가 commonMain에 포함되지 않았는지
+          - Coroutine / Flow 사용이 멀티플랫폼 환경에서 안전한지
+          - Compose 공통 UI가 특정 플랫폼 동작을 가정하지 않는지
+          - 하드코딩된 값(문자열, 숫자, URL, 키 등)을 반드시 지적하고, 상수 또는 설정 파일로 분리하도록 제안하세요.
+          - Dependency Injection은 **Metro DI**를 사용하고 있으므로,Hilt/Koin 기준이 아닌 Metro 기준으로 리뷰해 주세요.
+          - @Provides, @ContributesBinding, component 구조 등 Metro 패턴에 맞는지 확인해 주세요.
+
+          각 리뷰 지적에는 가능하면 Kotlin Multiplatform 또는
+          Compose Multiplatform 공식 문서를 근거 링크로 첨부해 주세요.
+
+          이 PR의 composeApp/androidMain/** 에 해당하는 코드는 Android 코드에 한해서 다음을 중점적으로 리뷰해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - expect / actual 구현의 책임이 androidMain에 적절히 위치했는지
+          - Android 공식 가이드라인 및 Jetpack 권장 사항
+          - Android 전용 API 사용의 적절성
+          - 불필요하게 복잡한 코드나 중복 로직
+
+          각 리뷰 지적에는 Android 공식 문서 링크를 근거로 첨부해 주세요.
+
+          이 PR의 composeApp/iosMain/** 에 해당하는 코드는 iOS 전용 Kotlin 코드에 대해 다음을 중점적으로 리뷰해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - expect / actual 구현의 책임이 iosMain에 적절히 위치했는지
+          - iOS 플랫폼 API 접근 방식이 안전한지
+          - commonMain과의 의존 방향이 올바른지
+
+          각 리뷰 지적에는 Kotlin Multiplatform iOS 관련 공식 문서를
+          근거 링크로 첨부해 주세요.
+                  "
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,13 +2,13 @@ name: Claude Code
 
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
   pull_request_review_comment:
-    types: [created]
+    types: [ created ]
   issues:
-    types: [opened, assigned]
+    types: [ opened, assigned ]
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
 
 jobs:
   claude:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write 
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -35,7 +35,43 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          
+          GitHub PR을 원격에서 리뷰하고 꼭 라인별 코멘트를 게시해 주세요. 
+          이 PR의 composeApp/commonMain/** 에 해당하는 코드는 Compose Multiplatform 관점에서 리뷰해 주세요.
+          특히 다음을 확인해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - 플랫폼(Android/iOS/Desktop) 의존 API가 commonMain에 직접 사용되지 않았는지
+          - expect / actual 분리가 필요한 코드가 commonMain에 포함되지 않았는지
+          - Coroutine / Flow 사용이 멀티플랫폼 환경에서 안전한지
+          - Compose 공통 UI가 특정 플랫폼 동작을 가정하지 않는지
+          - 하드코딩된 값(문자열, 숫자, URL, 키 등)을 반드시 지적하고, 상수 또는 설정 파일로 분리하도록 제안하세요.
+          - Dependency Injection은 **Metro DI**를 사용하고 있으므로,Hilt/Koin 기준이 아닌 Metro 기준으로 리뷰해 주세요.
+          - @Provides, @ContributesBinding, component 구조 등 Metro 패턴에 맞는지 확인해 주세요.
+  
+          각 리뷰 지적에는 가능하면 Kotlin Multiplatform 또는
+          Compose Multiplatform 공식 문서를 근거 링크로 첨부해 주세요.
+          
+          이 PR의 composeApp/androidMain/** 에 해당하는 코드는 Android 코드에 한해서 다음을 중점적으로 리뷰해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - expect / actual 구현의 책임이 androidMain에 적절히 위치했는지
+          - Android 공식 가이드라인 및 Jetpack 권장 사항
+          - Android 전용 API 사용의 적절성
+          - 불필요하게 복잡한 코드나 중복 로직
+  
+          각 리뷰 지적에는 Android 공식 문서 링크를 근거로 첨부해 주세요.
+          
+          이 PR의 composeApp/iosMain/** 에 해당하는 코드는 iOS 전용 Kotlin 코드에 대해 다음을 중점적으로 리뷰해 주세요.
+          - Kotlin 코딩 컨벤션 및 네이밍 규칙
+          - expect / actual 구현의 책임이 iosMain에 적절히 위치했는지
+          - iOS 플랫폼 API 접근 방식이 안전한지
+          - commonMain과의 의존 방향이 올바른지
+  
+          각 리뷰 지적에는 Kotlin Multiplatform iOS 관련 공식 문서를
+          근거 링크로 첨부해 주세요.
+        "
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
chore: Claude Code Action 프롬프트 상세화 및 워크플로우 포맷팅 수정

* **chore: `.github/workflows/claude.yml` 내 트리거 구문 포맷 수정**
    * 가독성 향상을 위해 `on` 이벤트의 `types` 배열 요소 전후에 공백을 추가했습니다.

* **feat: Claude Code Action에 플랫폼별 상세 리뷰 가이드라인 추가**
    * **commonMain**: Kotlin Multiplatform 컨벤션, 플랫폼 의존성 배제, Metro DI 패턴 준수 여부 및 Coroutine/Flow 사용 안전성을 검토하도록 프롬프트를 추가했습니다.
    * **androidMain**: Android 공식 가이드라인, Jetpack 권장 사항 및 `expect/actual` 구현의 적절성을 검토하도록 지시했습니다.
    * **iosMain**: iOS 플랫폼 API 접근의 안전성 및 의존성 방향의 적절성을 검토하도록 지시했습니다.
    * **공통**: 하드코딩된 값 지적 및 리뷰 시 공식 문서 근거 링크를 첨부하도록 상세 지침을 구성했습니다.

## #️⃣ 이슈 번호

> ex) #이슈번호, #이슈번호

<br>

## 🛠️ 작업 내용

- 구현한 기능을 작성해주세요.

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  - 코드 리뷰 자동화 기능이 강화되었습니다.
  - 워크플로우 자동화의 권한이 개선되어 더욱 효율적인 pull request 처리가 가능해졌습니다.
  - 다중 플랫폼 대상에 대한 코드 리뷰 지침이 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->