### PR TITLE
[Feat]: ExploreScreen CMP 마이그레이션

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/MainActivity.kt
@@ -9,8 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.imageLoader
-import com.daedan.festabook.presentation.platform.rememberAppVersionManager
-import com.daedan.festabook.presentation.splash.component.SplashScreen
+import com.daedan.festabook.presentation.explore.component.ExploreScreen
 import com.daedan.festabook.presentation.theme.FestabookTheme
 import com.skydoves.landscapist.coil3.LocalCoilImageLoader
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
@@ -32,17 +31,10 @@ class MainActivity : ComponentActivity() {
                     LocalCoilImageLoader provides imageLoader,
                 ) {
                     Scaffold { innerPadding ->
-                        SplashScreen(
-                            viewModel = viewModel(factory = metroVmf),
-                            appVersionManager =
-                                rememberAppVersionManager(
-                                    appGraph = (application as FestabookApp).festabookAppGraph,
-                                    onUpdateFailure = {},
-                                    onUpdateSuccess = {},
-                                ),
+                        ExploreScreen(
                             onNavigateToMain = {},
-                            onNavigateToExplore = {},
-                            onFinishApp = { finish() },
+                            onBackClick = {},
+                            viewModel = viewModel(factory = metroVmf),
                         )
                     }
                 }

--- a/composeApp/src/commonMain/composeResources/drawable/ic_arrow_back.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_arrow_back.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
-    <path android:fillColor="@android:color/white" android:pathData="M21,11H6.83l3.58,-3.59L9,6l-6,6 6,6 1.41,-1.41L6.83,13H21z"/>
+    <path android:fillColor="#FF000000" android:pathData="M21,11H6.83l3.58,-3.59L9,6l-6,6 6,6 1.41,-1.41L6.83,13H21z"/>
     
 </vector>

--- a/composeApp/src/commonMain/composeResources/drawable/ic_close.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_close.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
-    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+    <path android:fillColor="#FF000000" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
     
 </vector>

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreSideEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreSideEffect.kt
@@ -1,0 +1,9 @@
+package com.daedan.festabook.presentation.explore
+
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+
+sealed interface ExploreSideEffect {
+    data class NavigateToMain(
+        val searchResult: SearchResultUiModel,
+    ) : ExploreSideEffect
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreUiState.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.presentation.explore
+
+data class ExploreUiState(
+    val query: String = "",
+    val searchState: SearchUiState = SearchUiState.Idle,
+    val hasFestivalId: Boolean = false,
+)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -1,0 +1,95 @@
+package com.daedan.festabook.presentation.explore
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daedan.festabook.di.viewmodel.ViewModelKey
+import com.daedan.festabook.domain.repository.ExploreRepository
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.explore.model.toUiModel
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@OptIn(FlowPreview::class)
+@ContributesIntoMap(AppScope::class)
+@ViewModelKey(ExploreViewModel::class)
+@Inject
+class ExploreViewModel(
+    private val exploreRepository: ExploreRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ExploreUiState())
+    val uiState: StateFlow<ExploreUiState> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<ExploreSideEffect>(replay = 0, extraBufferCapacity = 1)
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    init {
+        checkFestivalId()
+        observeSearchQuery()
+    }
+
+    private fun checkFestivalId() {
+        viewModelScope.launch {
+            val festivalId = exploreRepository.getFestivalId()
+//        Timber.d("festival ID : $festivalId")
+            if (festivalId != null) {
+                _uiState.update { it.copy(hasFestivalId = true) }
+            }
+        }
+    }
+
+    private fun observeSearchQuery() {
+        viewModelScope.launch {
+            _uiState
+                .map { it.query }
+                .distinctUntilChanged()
+                .debounce(300L)
+                .collectLatest { query ->
+                    if (query.isBlank()) {
+                        _uiState.update { it.copy(searchState = SearchUiState.Idle) }
+                        return@collectLatest
+                    }
+
+                    _uiState.update { it.copy(searchState = SearchUiState.Loading) }
+
+                    exploreRepository
+                        .search(query)
+                        .onSuccess { universitiesFound ->
+//                            Timber.d("검색 성공 - received: $universitiesFound")
+                            val uiModels = universitiesFound.map { it.toUiModel() }
+                            _uiState.update {
+                                it.copy(searchState = SearchUiState.Success(universitiesFound = uiModels))
+                            }
+                        }.onFailure { throwable ->
+//                            Timber.d(throwable, "검색 실패")
+                            _uiState.update {
+                                it.copy(searchState = SearchUiState.Error(throwable))
+                            }
+                        }
+                }
+        }
+    }
+
+    fun onUniversitySelected(university: SearchResultUiModel) {
+        viewModelScope.launch {
+            exploreRepository.saveFestivalId(university.festivalId)
+            _sideEffect.emit(ExploreSideEffect.NavigateToMain(university))
+        }
+    }
+
+    fun onTextInputChanged(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/SearchUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/SearchUiState.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.presentation.explore
+
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+
+sealed interface SearchUiState {
+    val isEmptyResult: Boolean get() = false
+    val isFailure: Boolean get() = this is Error
+    val shouldShowErrorUi: Boolean get() = isFailure || isEmptyResult
+
+    data object Idle : SearchUiState
+
+    data object Loading : SearchUiState
+
+    data class Success(
+        val universitiesFound: List<SearchResultUiModel> = emptyList(),
+//        val selectedUniversity: University? = null,
+    ) : SearchUiState {
+        override val isEmptyResult: Boolean
+            get() = universitiesFound.isEmpty()
+    }
+
+    data class Error(
+        val throwable: Throwable,
+    ) : SearchUiState
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreBackHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreBackHeader.kt
@@ -1,0 +1,51 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.explore_back
+import festabookkmp.composeapp.generated.resources.ic_arrow_back
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreBackHeader(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(56.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        IconButton(
+            onClick = onBackClick,
+        ) {
+            Icon(
+                imageVector = vectorResource(Res.drawable.ic_arrow_back),
+                contentDescription = stringResource(Res.string.explore_back),
+                tint = Color.Unspecified,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreBackHeaderPreview() {
+    FestabookTheme {
+        ExploreBackHeader(onBackClick = {})
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreResultItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreResultItem.kt
@@ -1,0 +1,52 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.theme.FestabookColor
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import com.daedan.festabook.presentation.theme.FestabookTypography
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreResultItem(
+    university: SearchResultUiModel,
+    onItemClick: (SearchResultUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable { onItemClick(university) }
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+    ) {
+        Text(
+            text = university.universityName,
+            style = FestabookTypography.bodyLarge,
+            color = FestabookColor.gray800,
+        )
+        Text(
+            text = university.festivalName,
+            style = FestabookTypography.bodySmall,
+            color = FestabookColor.gray600,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreResultItemPreview() {
+    FestabookTheme {
+        ExploreResultItem(
+            university = SearchResultUiModel(1, "서울시립대학교", "2024 대동제"),
+            onItemClick = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
@@ -187,7 +187,6 @@ fun ExploreLandingScreen(
                         ExploreSearchResultList(
                             searchState = searchState,
                             onUniversitySelect = onUniversitySelect,
-                            modifier = Modifier.weight(1f),
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
@@ -1,0 +1,226 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.daedan.festabook.presentation.explore.ExploreSideEffect
+import com.daedan.festabook.presentation.explore.ExploreViewModel
+import com.daedan.festabook.presentation.explore.SearchUiState
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.explore_festabook_logo
+import festabookkmp.composeapp.generated.resources.logo_title
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreScreen(
+    onNavigateToMain: (SearchResultUiModel) -> Unit,
+    onBackClick: () -> Unit,
+    viewModel: ExploreViewModel,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val latestNavigateToMain by rememberUpdatedState(onNavigateToMain)
+    val latestKeyboardController by rememberUpdatedState(keyboardController)
+
+    LaunchedEffect(viewModel) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ExploreSideEffect.NavigateToMain -> {
+                    latestKeyboardController?.hide()
+                    latestNavigateToMain(effect.searchResult)
+                }
+            }
+        }
+    }
+
+    if (uiState.hasFestivalId) {
+        ExploreSearchScreen(
+            query = uiState.query,
+            searchState = uiState.searchState,
+            onQueryChange = viewModel::onTextInputChanged,
+            onUniversitySelect = viewModel::onUniversitySelected,
+            onBackClick = onBackClick,
+        )
+    } else {
+        ExploreLandingScreen(
+            query = uiState.query,
+            searchState = uiState.searchState,
+            onQueryChange = viewModel::onTextInputChanged,
+            onUniversitySelect = viewModel::onUniversitySelected,
+        )
+    }
+}
+
+@Composable
+fun ExploreSearchScreen(
+    query: String,
+    searchState: SearchUiState,
+    onQueryChange: (String) -> Unit,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = Color.White,
+        topBar = {
+            ExploreBackHeader(
+                onBackClick = onBackClick,
+                modifier = Modifier.statusBarsPadding(),
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(20.dp),
+        ) {
+            ExploreSearchContent(
+                query = query,
+                searchState = searchState,
+                onQueryChange = onQueryChange,
+                onUniversitySelect = onUniversitySelect,
+            )
+        }
+    }
+}
+
+@Composable
+fun ExploreLandingScreen(
+    query: String,
+    searchState: SearchUiState,
+    onQueryChange: (String) -> Unit,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val isError = searchState.shouldShowErrorUi
+
+    val isSearchMode = query.isNotBlank()
+
+    Scaffold(
+        modifier = modifier,
+        containerColor = Color.White,
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .imePadding()
+                    .clickable(
+                        onClick = {
+                            keyboardController?.hide()
+                        },
+                        indication = null,
+                        interactionSource = null,
+                    ),
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .padding(top = 16.dp)
+                        .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(
+                    modifier =
+                        Modifier
+                            .weight(0.3f),
+                )
+
+                Image(
+                    painter = painterResource(Res.drawable.logo_title),
+                    contentDescription = stringResource(Res.string.explore_festabook_logo),
+                    modifier = Modifier.height(24.dp),
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+                ExploreSearchBar(
+                    query = query,
+                    onQueryChange = onQueryChange,
+                    onSearch = { keyboardController?.hide() },
+                    isError = isError,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                )
+
+                AnimatedContent(
+                    targetState = isSearchMode,
+                    transitionSpec = {
+                        ContentTransform(
+                            targetContentEnter = fadeIn(tween(200)),
+                            initialContentExit = fadeOut(tween(200)),
+                        )
+                    },
+                ) { searching ->
+                    if (searching) {
+                        ExploreSearchResultList(
+                            searchState = searchState,
+                            onUniversitySelect = onUniversitySelect,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(0.7f))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchScreenPreview() {
+    FestabookTheme {
+        ExploreSearchScreen(
+            query = "서울",
+            searchState = SearchUiState.Idle,
+            onQueryChange = {},
+            onUniversitySelect = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreLandingScreenPreview() {
+    FestabookTheme {
+        ExploreLandingScreen(
+            query = "ㅇㄹㅇ",
+            searchState = SearchUiState.Idle,
+            onQueryChange = {},
+            onUniversitySelect = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchBar.kt
@@ -1,0 +1,144 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.theme.FestabookColor
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import com.daedan.festabook.presentation.theme.FestabookTypography
+import com.daedan.festabook.presentation.theme.festabookShapes
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.explore_no_search_result_text
+import festabookkmp.composeapp.generated.resources.explore_search_hint_text
+import festabookkmp.composeapp.generated.resources.ic_close
+import festabookkmp.composeapp.generated.resources.ic_search
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    isError: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier =
+            modifier
+                .fillMaxWidth(),
+        placeholder = {
+            Text(
+                text = stringResource(Res.string.explore_search_hint_text),
+                style = FestabookTypography.titleMedium,
+                color = FestabookColor.gray400,
+            )
+        },
+        supportingText =
+            if (isError) {
+                {
+                    Text(
+                        stringResource(Res.string.explore_no_search_result_text),
+                        color = FestabookColor.error,
+                    )
+                }
+            } else {
+                null
+            },
+        singleLine = true,
+        textStyle =
+            FestabookTypography.titleMedium.copy(
+                color = FestabookColor.gray800,
+            ),
+        shape = festabookShapes.radiusFull,
+        colors =
+            OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = FestabookColor.gray800,
+                unfocusedBorderColor = FestabookColor.gray400,
+                errorBorderColor = FestabookColor.error,
+                cursorColor = FestabookColor.gray800,
+                errorCursorColor = FestabookColor.error,
+                disabledBorderColor = Color.Transparent,
+                errorContainerColor = Color.Transparent,
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+            ),
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_close),
+                        contentDescription = "Clear text",
+                        tint = Color.Unspecified,
+                    )
+                }
+            } else {
+                IconButton(onClick = { onSearch(query) }) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_search),
+                        contentDescription = "Search",
+                        tint = Color.Unspecified,
+                    )
+                }
+            }
+        },
+        keyboardOptions =
+            KeyboardOptions(
+                imeAction = ImeAction.Search,
+                showKeyboardOnFocus = true,
+            ),
+        keyboardActions =
+            KeyboardActions(
+                onSearch = {
+                    onSearch(query)
+                    keyboardController?.hide()
+                },
+            ),
+        isError = isError,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchBarPreview() {
+    FestabookTheme {
+        ExploreSearchBar(
+            query = "",
+            onQueryChange = {},
+            isError = false,
+            modifier = Modifier.padding(16.dp),
+            onSearch = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchBarErrorPreview() {
+    FestabookTheme {
+        ExploreSearchBar(
+            query = "서울시립대학교",
+            onQueryChange = {},
+            isError = true,
+            modifier = Modifier.padding(16.dp),
+            onSearch = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
@@ -1,0 +1,66 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.SearchUiState
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreSearchContent(
+    query: String,
+    searchState: SearchUiState,
+    onQueryChange: (String) -> Unit,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val isError = searchState.shouldShowErrorUi
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize(),
+    ) {
+        Box(modifier = Modifier.padding(bottom = 16.dp)) {
+            ExploreSearchBar(
+                query = query,
+                onQueryChange = onQueryChange,
+                onSearch = { keyboardController?.hide() },
+                isError = isError,
+            )
+        }
+
+        ExploreSearchResultList(
+            searchState = searchState,
+            onUniversitySelect = onUniversitySelect,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchContentPreview() {
+    FestabookTheme {
+        ExploreSearchContent(
+            query = "서울",
+            searchState =
+                SearchUiState.Success(
+                    listOf(
+                        SearchResultUiModel(1, "서울시립대학교", "2024 대동제"),
+                        SearchResultUiModel(2, "서울대학교", "2024 봄축제"),
+                    ),
+                ),
+            onQueryChange = {},
+            onUniversitySelect = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
@@ -1,0 +1,88 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.SearchUiState
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.theme.FestabookColor
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ExploreSearchResultList(
+    searchState: SearchUiState,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp),
+    ) {
+        when (searchState) {
+            is SearchUiState.Loading -> {
+                item {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(top = 20.dp),
+                            color = FestabookColor.accentBlue,
+                        )
+                    }
+                }
+            }
+
+            is SearchUiState.Success -> {
+                items(searchState.universitiesFound) { university ->
+                    ExploreResultItem(
+                        university = university,
+                        onItemClick = onUniversitySelect,
+                    )
+                }
+            }
+
+            is SearchUiState.Error -> {}
+
+            is SearchUiState.Idle -> {}
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchResultListLoadingPreview() {
+    FestabookTheme {
+        ExploreSearchResultList(
+            searchState = SearchUiState.Loading,
+            onUniversitySelect = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreSearchResultListSuccessPreview() {
+    val fakeUniversities =
+        listOf(
+            SearchResultUiModel(1, "서울대학교", "대동제"),
+            SearchResultUiModel(2, "서울시립대학교", "대동제"),
+        )
+    FestabookTheme {
+        ExploreSearchResultList(
+            searchState =
+                SearchUiState.Success(
+                    universitiesFound = fakeUniversities,
+                ),
+            onUniversitySelect = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/model/SearchResultUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/model/SearchResultUiModel.kt
@@ -1,0 +1,16 @@
+package com.daedan.festabook.presentation.explore.model
+
+import com.daedan.festabook.domain.model.FestivalSearchItem
+
+data class SearchResultUiModel(
+    val festivalId: Long,
+    val universityName: String,
+    val festivalName: String,
+)
+
+fun FestivalSearchItem.toUiModel(): SearchResultUiModel =
+    SearchResultUiModel(
+        festivalId = festivalId,
+        universityName = organizationName,
+        festivalName = festivalName.replace("\n", " "),
+    )


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/63

<br>

## 🛠️ 작업 내용

- ExploreScreen을 Compose로 마이그레이션 하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 축제 탐색 화면 추가 — 대학/축제명 검색, 자동(디바운스) 검색, 로딩/오류/빈결과 처리
  * 검색 결과 목록 및 항목 선택 기능 — 선택 시 축제 식별자 저장 후 메인으로 이동
  * 뒤로가기 헤더, 검색 바, 결과 항목 등 컴포저블 UI와 키보드/포커스 동작 개선

* **스타일**
  * 뒤로가기·닫기 아이콘 색상을 검정(#FF000000)으로 변경

* **변경**
  * 앱 시작 시 스플래시 대신 탐색 화면을 직접 표시하도록 전환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->