### PR TITLE
[Feat] FestabookScreen 및 Compose Navigation 마이그레이션

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -87,6 +87,7 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(libs.compose.navigationevent)
+            implementation(libs.compose.navigation)
             implementation(libs.coil.compose)
             implementation(libs.landscapist.coil3)
             implementation(libs.landscapist.placeholder)
@@ -94,6 +95,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)
+            implementation(libs.compose.navigation)
             implementation(libs.material.icons.core)
             implementation(compose.ui)
             implementation(compose.components.resources)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -95,7 +95,6 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)
-            implementation(libs.compose.navigation)
             implementation(libs.material.icons.core)
             implementation(compose.ui)
             implementation(compose.components.resources)

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/MainActivity.kt
@@ -4,15 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.lifecycle.viewmodel.compose.viewModel
-import coil3.imageLoader
-import com.daedan.festabook.presentation.explore.component.ExploreScreen
+import com.daedan.festabook.presentation.FestabookScreen
 import com.daedan.festabook.presentation.theme.FestabookTheme
-import com.skydoves.landscapist.coil3.LocalCoilImageLoader
-import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 class MainActivity : ComponentActivity() {
@@ -26,18 +20,9 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             FestabookTheme {
-                CompositionLocalProvider(
-                    LocalMetroViewModelFactory provides metroVmf,
-                    LocalCoilImageLoader provides imageLoader,
-                ) {
-                    Scaffold { innerPadding ->
-                        ExploreScreen(
-                            onNavigateToMain = {},
-                            onBackClick = {},
-                            viewModel = viewModel(factory = metroVmf),
-                        )
-                    }
-                }
+                FestabookScreen(
+                    onAppFinish = ::finish,
+                )
             }
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
@@ -1,6 +1,8 @@
 package com.daedan.festabook.di
 
 import android.app.Application
+import android.content.Context
+import com.daedan.festabook.FestabookApp
 import com.daedan.festabook.presentation.splash.platform.AppVersionManager
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
@@ -30,3 +32,5 @@ interface AndroidAppGraph : FestabookAppGraph {
     @SingleIn(AppScope::class)
     fun provideCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }
+
+val Context.appGraph get() = (applicationContext as FestabookApp).festabookAppGraph

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.android.kt
@@ -1,0 +1,13 @@
+package com.daedan.festabook.presentation.platform
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.daedan.festabook.di.FestabookAppGraph
+import com.daedan.festabook.di.appGraph
+
+@Composable
+actual fun rememberAppGraph(): FestabookAppGraph {
+    val context = LocalContext.current
+    return remember(context) { context.appGraph }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
+import com.daedan.festabook.di.FestabookAppGraph
 import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
 import com.daedan.festabook.presentation.main.FestabookRoute
 import com.daedan.festabook.presentation.main.rememberFestabookNavigator
@@ -18,9 +19,9 @@ import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
 fun FestabookScreen(
     onAppFinish: () -> Unit,
     modifier: Modifier = Modifier,
-    splashViewModel: SplashViewModel = viewModel(),
+    appGraph: FestabookAppGraph = rememberAppGraph(),
+    splashViewModel: SplashViewModel = viewModel(factory = appGraph.metroViewModelFactory),
 ) {
-    val appGraph = rememberAppGraph()
     val locationSource = rememberLocationSource()
     val festabookNavigator = rememberFestabookNavigator()
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -1,0 +1,67 @@
+package com.daedan.festabook.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.navOptions
+import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
+import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.rememberFestabookNavigator
+import com.daedan.festabook.presentation.platform.rememberAppGraph
+import com.daedan.festabook.presentation.platform.rememberAppVersionManager
+import com.daedan.festabook.presentation.platform.rememberLocationSource
+import com.daedan.festabook.presentation.splash.SplashViewModel
+import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
+
+@Composable
+fun FestabookScreen(
+    onAppFinish: () -> Unit,
+    modifier: Modifier = Modifier,
+    splashViewModel: SplashViewModel = viewModel(),
+) {
+    val appGraph = rememberAppGraph()
+    val locationSource = rememberLocationSource()
+    val festabookNavigator = rememberFestabookNavigator()
+
+    val appVersionManager =
+        rememberAppVersionManager(
+            appGraph = appGraph,
+            onUpdateSuccess = { splashViewModel.handleVersionCheckResult(Result.success(false)) },
+            onUpdateFailure = { splashViewModel.handleVersionCheckResult(Result.failure(Exception("Update failed"))) },
+        )
+
+    NavHost(
+        modifier = modifier,
+        startDestination = festabookNavigator.startRoute,
+        navController = festabookNavigator.navController,
+    ) {
+        splashNavGraph(
+            appGraph = appGraph,
+            appVersionManager = appVersionManager,
+            onNavigateToExplore = {
+                festabookNavigator.navigate(
+                    FestabookRoute.Explore,
+                    navOptions {
+                        popUpTo(FestabookRoute.Splash) {
+                            inclusive = true
+                        }
+                    },
+                )
+            },
+            onNavigateToMain = { festabookNavigator.navigate(FestabookRoute.Main) },
+            onFinishApp = onAppFinish,
+        )
+        exploreNavGraph(
+            appGraph = appGraph,
+            onBackClick = { festabookNavigator.popBackStack() },
+            onNavigateToMain = { festabookNavigator.navigate(FestabookRoute.Main) },
+        )
+//        mainNavGraph(
+//            appGraph = appGraph,
+//            onAppFinish = onAppFinish,
+//            locationSource = locationSource,
+//            festabookNavigator = festabookNavigator,
+//        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -38,7 +38,6 @@ fun FestabookScreen(
         navController = festabookNavigator.navController,
     ) {
         splashNavGraph(
-            appGraph = appGraph,
             appVersionManager = appVersionManager,
             onNavigateToExplore = {
                 festabookNavigator.navigate(
@@ -54,7 +53,6 @@ fun FestabookScreen(
             onFinishApp = onAppFinish,
         )
         exploreNavGraph(
-            appGraph = appGraph,
             onBackClick = { festabookNavigator.popBackStack() },
             onNavigateToMain = { festabookNavigator.navigate(FestabookRoute.Main) },
         )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/common/component/CoilImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/common/component/CoilImage.kt
@@ -9,6 +9,9 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import com.daedan.festabook.presentation.common.convertImageUrl
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.img_fallback
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -30,6 +33,7 @@ fun CoilImage(
         contentScale = contentScale,
         placeholder = ColorPainter(Color.LightGray),
         modifier = modifier,
+        fallback = painterResource(Res.drawable.img_fallback),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
@@ -6,15 +6,16 @@ import androidx.navigation.compose.composable
 import com.daedan.festabook.di.FestabookAppGraph
 import com.daedan.festabook.presentation.explore.component.ExploreScreen
 import com.daedan.festabook.presentation.main.FestabookRoute
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
 fun NavGraphBuilder.exploreNavGraph(
-    appGraph: FestabookAppGraph,
     onBackClick: () -> Unit,
     onNavigateToMain: () -> Unit,
 ) {
     composable<FestabookRoute.Explore> {
+        val viewModelFactory = LocalMetroViewModelFactory.current
         ExploreScreen(
-            viewModel = viewModel(factory = appGraph.metroViewModelFactory),
+            viewModel = viewModel(factory = viewModelFactory),
             onBackClick = onBackClick,
             onNavigateToMain = { onNavigateToMain() },
         )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
@@ -3,7 +3,6 @@ package com.daedan.festabook.presentation.explore.navigation
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.daedan.festabook.di.FestabookAppGraph
 import com.daedan.festabook.presentation.explore.component.ExploreScreen
 import com.daedan.festabook.presentation.main.FestabookRoute
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
@@ -1,0 +1,22 @@
+package com.daedan.festabook.presentation.explore.navigation
+
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.daedan.festabook.di.FestabookAppGraph
+import com.daedan.festabook.presentation.explore.component.ExploreScreen
+import com.daedan.festabook.presentation.main.FestabookRoute
+
+fun NavGraphBuilder.exploreNavGraph(
+    appGraph: FestabookAppGraph,
+    onBackClick: () -> Unit,
+    onNavigateToMain: () -> Unit,
+) {
+    composable<FestabookRoute.Explore> {
+        ExploreScreen(
+            viewModel = viewModel(factory = appGraph.metroViewModelFactory),
+            onBackClick = onBackClick,
+            onNavigateToMain = { onNavigateToMain() },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookMainTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookMainTab.kt
@@ -1,0 +1,69 @@
+package com.daedan.festabook.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import com.daedan.festabook.presentation.theme.FestabookColor
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.ic_home
+import festabookkmp.composeapp.generated.resources.ic_map
+import festabookkmp.composeapp.generated.resources.ic_news
+import festabookkmp.composeapp.generated.resources.ic_schedule
+import festabookkmp.composeapp.generated.resources.ic_setting
+import festabookkmp.composeapp.generated.resources.menu_home_title
+import festabookkmp.composeapp.generated.resources.menu_map_title
+import festabookkmp.composeapp.generated.resources.menu_news_title
+import festabookkmp.composeapp.generated.resources.menu_schedule_title
+import festabookkmp.composeapp.generated.resources.menu_setting_title
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
+
+enum class FestabookMainTab(
+    val iconResId: DrawableResource,
+    val labelResId: StringResource,
+    val route: MainTabRoute,
+) {
+    HOME(
+        iconResId = Res.drawable.ic_home,
+        labelResId = Res.string.menu_home_title,
+        route = MainTabRoute.Home,
+    ),
+    SCHEDULE(
+        iconResId = Res.drawable.ic_schedule,
+        labelResId = Res.string.menu_schedule_title,
+        route = MainTabRoute.Schedule,
+    ),
+    PLACE_MAP(
+        iconResId = Res.drawable.ic_map,
+        labelResId = Res.string.menu_map_title,
+        route = MainTabRoute.PlaceMap,
+    ),
+    NEWS(
+        iconResId = Res.drawable.ic_news,
+        labelResId = Res.string.menu_news_title,
+        route = MainTabRoute.News,
+    ),
+    SETTING(
+        iconResId = Res.drawable.ic_setting,
+        labelResId = Res.string.menu_setting_title,
+        route = MainTabRoute.Setting,
+    ),
+    ;
+
+    companion object Defaults {
+        @Composable
+        fun find(predicate: @Composable (FestabookRoute) -> Boolean) =
+            entries.find {
+                predicate(it.route)
+            }
+
+        val selectedColor
+            @Composable
+            @ReadOnlyComposable
+            get() = FestabookColor.black
+
+        val unselectedColor
+            @Composable
+            @ReadOnlyComposable
+            get() = FestabookColor.gray400
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookNavigator.kt
@@ -1,0 +1,81 @@
+package com.daedan.festabook.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
+
+class FestabookNavigator(
+    val navController: NavHostController,
+    val startRoute: FestabookRoute = FestabookRoute.Splash,
+) {
+    private val currentDestination
+        @Composable
+        get() =
+            navController
+                .visibleEntries
+                .collectAsState()
+                .value
+                .lastOrNull { it.destination.route != null }
+                ?.destination
+    val currentTab
+        @Composable
+        get() =
+            FestabookMainTab.find {
+                currentDestination?.hasRoute(it::class) ?: false
+            }
+
+    val shouldShowBottomBar
+        @Composable
+        get() =
+            FestabookMainTab.find {
+                currentDestination?.hasRoute(it::class) ?: false
+            } != null
+
+    fun navigateToMainTab(tab: FestabookMainTab) {
+        navController.navigate(
+            tab.route,
+            navOptions {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            },
+        )
+    }
+
+    fun navigate(
+        route: FestabookRoute,
+        navOptions: NavOptions? = null,
+    ) {
+        navController.navigate(
+            route,
+            navOptions,
+        )
+    }
+
+    fun popBackStack() {
+        navController.popBackStack()
+    }
+
+    fun popBackStack(
+        route: FestabookRoute,
+        inclusive: Boolean = false,
+    ) {
+        navController.popBackStack(route, inclusive)
+    }
+}
+
+@Composable
+fun rememberFestabookNavigator(startRoute: FestabookRoute = FestabookRoute.Splash): FestabookNavigator {
+    val navController = rememberNavController()
+    return remember {
+        FestabookNavigator(navController = navController, startRoute = startRoute)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/FestabookRoute.kt
@@ -1,0 +1,41 @@
+package com.daedan.festabook.presentation.main
+
+import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface FestabookRoute {
+    @Serializable
+    data object Splash : FestabookRoute
+
+    @Serializable
+    data class PlaceDetail(
+        val placeUiModel: PlaceUiModel? = null,
+        val placeDetailUiModel: PlaceDetailUiModel? = null,
+    ) : FestabookRoute
+
+    @Serializable
+    data object Explore : FestabookRoute
+
+    @Serializable
+    data object Main : FestabookRoute
+}
+
+@Serializable
+sealed interface MainTabRoute : FestabookRoute {
+    @Serializable
+    data object Home : MainTabRoute
+
+    @Serializable
+    data object Schedule : MainTabRoute
+
+    @Serializable
+    data object PlaceMap : MainTabRoute
+
+    @Serializable
+    data object News : MainTabRoute
+
+    @Serializable
+    data object Setting : MainTabRoute
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.presentation.platform
+
+import androidx.compose.runtime.Composable
+import com.daedan.festabook.di.FestabookAppGraph
+
+@Composable
+expect fun rememberAppGraph(): FestabookAppGraph

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
@@ -7,17 +7,18 @@ import com.daedan.festabook.di.FestabookAppGraph
 import com.daedan.festabook.presentation.main.FestabookRoute
 import com.daedan.festabook.presentation.splash.component.SplashScreen
 import com.daedan.festabook.presentation.splash.platform.AppVersionManager
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
 fun NavGraphBuilder.splashNavGraph(
-    appGraph: FestabookAppGraph,
     appVersionManager: AppVersionManager,
     onNavigateToExplore: () -> Unit,
     onNavigateToMain: (Long) -> Unit,
     onFinishApp: () -> Unit,
 ) {
     composable<FestabookRoute.Splash> {
+        val viewModelFactory = LocalMetroViewModelFactory.current
         SplashScreen(
-            viewModel = viewModel(factory = appGraph.metroViewModelFactory),
+            viewModel = viewModel(factory = viewModelFactory),
             appVersionManager = appVersionManager,
             onNavigateToExplore = onNavigateToExplore,
             onNavigateToMain = onNavigateToMain,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.splash.navigation
+
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.daedan.festabook.di.FestabookAppGraph
+import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.splash.component.SplashScreen
+import com.daedan.festabook.presentation.splash.platform.AppVersionManager
+
+fun NavGraphBuilder.splashNavGraph(
+    appGraph: FestabookAppGraph,
+    appVersionManager: AppVersionManager,
+    onNavigateToExplore: () -> Unit,
+    onNavigateToMain: (Long) -> Unit,
+    onFinishApp: () -> Unit,
+) {
+    composable<FestabookRoute.Splash> {
+        SplashScreen(
+            viewModel = viewModel(factory = appGraph.metroViewModelFactory),
+            appVersionManager = appVersionManager,
+            onNavigateToExplore = onNavigateToExplore,
+            onNavigateToMain = onNavigateToMain,
+            onFinishApp = onFinishApp,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
@@ -3,7 +3,6 @@ package com.daedan.festabook.presentation.splash.navigation
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.daedan.festabook.di.FestabookAppGraph
 import com.daedan.festabook.presentation.main.FestabookRoute
 import com.daedan.festabook.presentation.splash.component.SplashScreen
 import com.daedan.festabook.presentation.splash.platform.AppVersionManager

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/theme/FestabookTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/theme/FestabookTheme.kt
@@ -4,6 +4,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.compose.setSingletonImageLoaderFactory
+import coil3.request.crossfade
+import com.daedan.festabook.presentation.platform.rememberAppGraph
+import com.skydoves.landscapist.coil3.LocalCoilImageLoader
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
 private val LightColorScheme
     @Composable
@@ -18,12 +26,23 @@ fun FestabookTheme(content: @Composable () -> Unit) {
     val shapes = FestabookShapes()
     val color = FestabookColorPalette()
     val typography = FestabookTypographies
+    val appGraph = rememberAppGraph()
+    val platformContext = LocalPlatformContext.current
+
+    setSingletonImageLoaderFactory { context ->
+        ImageLoader
+            .Builder(context)
+            .crossfade(true)
+            .build()
+    }
 
     CompositionLocalProvider(
         LocalSpacing provides spacing,
         LocalShapes provides shapes,
         LocalColor provides color,
         LocalTypography provides typography,
+        LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
+        LocalCoilImageLoader provides SingletonImageLoader.get(platformContext),
     ) {
         MaterialTheme(
             colorScheme = LightColorScheme,

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/MainViewController.kt
@@ -1,45 +1,16 @@
 package com.daedan.festabook
 
-import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.window.ComposeUIViewController
-import androidx.lifecycle.viewmodel.compose.viewModel
-import coil3.SingletonImageLoader
-import coil3.compose.LocalPlatformContext
-import com.daedan.festabook.di.IosAppGraph
-import com.daedan.festabook.presentation.platform.rememberAppVersionManager
-import com.daedan.festabook.presentation.splash.component.SplashScreen
+import com.daedan.festabook.presentation.FestabookScreen
 import com.daedan.festabook.presentation.theme.FestabookTheme
-import com.skydoves.landscapist.coil3.LocalCoilImageLoader
-import dev.zacsweers.metro.createGraph
-import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import platform.posix.exit
-
-private val festabookAppGraph = createGraph<IosAppGraph>()
-private val metroVmf = festabookAppGraph.metroViewModelFactory
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() =
     ComposeUIViewController {
         FestabookTheme {
-            CompositionLocalProvider(
-                LocalMetroViewModelFactory provides metroVmf,
-                LocalCoilImageLoader provides SingletonImageLoader.get(LocalPlatformContext.current),
-            ) {
-                Scaffold { innerPadding ->
-                    SplashScreen(
-                        viewModel = viewModel(factory = metroVmf),
-                        appVersionManager =
-                            rememberAppVersionManager(
-                                appGraph = festabookAppGraph,
-                                onUpdateFailure = {},
-                                onUpdateSuccess = {},
-                            ),
-                        onNavigateToMain = {},
-                        onNavigateToExplore = {},
-                        onFinishApp = { exit(0) },
-                    )
-                }
-            }
+            FestabookScreen(
+                onAppFinish = { exit(0) },
+            )
         }
     }

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/platform/RememberAppGraph.ios.kt
@@ -1,0 +1,10 @@
+package com.daedan.festabook.presentation.platform
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.daedan.festabook.di.FestabookAppGraph
+import com.daedan.festabook.di.IosAppGraph
+import dev.zacsweers.metro.createGraph
+
+@Composable
+actual fun rememberAppGraph(): FestabookAppGraph = remember { createGraph<IosAppGraph>() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidx-testExt = "1.3.0"
 composeMultiplatform = "1.9.3"
 datastorePreferences = "1.2.0"
 compottie = "2.0.3"
+navigationCompose = "2.9.2"
 coil = "3.3.0"
 junit = "4.13.2"
 kotlin = "2.3.10"
@@ -43,6 +44,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
+compose-navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 compose-navigationevent = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "composeNavigationEvent" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "appUpdateKtx" }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/76

<br>

## 🛠️ 작업 내용

- FestabookScreen 및 Compose Navigation 마이그레이션 하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

1. 기존 metroViewModelFactory와 LocalCoilImage를 FestabookTheme으로 이동하였습니다. 
CMP에서는 따로 ImageLoader에 fallback, error image를 넣는 것이 어려워, CoilImage, FestabookImage 단에서 fallback 시, painter 객체를 넘겨주도록 하였습니다. 

2. Compose Navigation 의존성을 추가하였습니다. 지금은 별다른 수정 없이도 잘 작동하네요. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 탭 기반 메인 내비게이션 추가(홈, 일정, 장소 지도, 뉴스, 설정)
  * 통합 진입 화면(FestabookScreen)과 스플래시/탐색 네비게이션 그래프 도입
  * 전역 네비게이터 및 라우트 타입 추가로 내비게이션 상태 관리 개선

* **리팩토링**
  * 플랫폼별 앱 그래프 제공 방식 통합(안드로이드/iOS용 구현 추가)
  * 테마에서 의존성 및 이미지 로더를 전역으로 제공하도록 정리

* **스타일/기타**
  * 이미지 로더에 대체(fallback) 이미지 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->