### PR TITLE
[Feat] FirebaseAnalytics, Crashtics 마이그레이션

### DIFF
--- a/.github/workflows/cmp-ci.yml
+++ b/.github/workflows/cmp-ci.yml
@@ -46,6 +46,8 @@ jobs:
           echo "IMAGE_BASE_URL=${{ secrets.IMAGE_BASE_URL }}" >> local.properties
           echo "NAVER_MAP_CLIENT_ID=${{ secrets.NAVER_MAP_CLIENT_ID }}" >> local.properties
           echo "NAVER_MAP_STYLE_ID=${{ secrets.NAVER_MAP_STYLE_ID }}" >> local.properties
+          echo "APP_BUNDLE_ID=${{ secrets.APP_BUNDLE_ID }}" >> local.properties
+          echo "APP_BUNDLE_ID_DEV=${{ secrets.APP_BUNDLE_ID_DEV }}" >> local.properties
 
       - name: Load Google Service file
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ local.properties
 *.keystore
 google-services.json
 GoogleService-Info.plist
+GoogleService-Info-DEBUG.plist
+GoogleService-Info-RELEASE.plist
+
 
 /iosApp/Configuration/Debug.xcconfig
 /iosApp/Configuration/Release.xcconfig

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlint)
     alias(libs.plugins.kotlinCocoapods) apply false
+    alias(libs.plugins.google.gms.services) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -39,7 +39,7 @@ private val appBundleIdDev =
     getLocalProperty("APP_BUNDLE_ID_DEV") ?: error("APP_BUNDLE_ID_DEV가 local.properties에 없음")
 
 private val buildFlavor =
-    project.properties["buildkonfig.flavor"].toString()
+    project.properties["buildkonfig.flavor"]?.toString() ?: "dev"
 
 
 plugins {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import com.google.devtools.ksp.gradle.KspAATask
 import dev.mokkery.gradle.ApplicationRule
+import org.gradle.kotlin.dsl.implementation
 import org.jetbrains.compose.internal.utils.getLocalProperty
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
@@ -31,6 +32,15 @@ private val naverMapStyleId =
 private val naverMapClientId =
     getLocalProperty("NAVER_MAP_CLIENT_ID") ?: error("NAVER_MAP_CLIENT_ID가 local.properties에 없음")
 
+private val appBundleId =
+    getLocalProperty("APP_BUNDLE_ID") ?: error("APP_BUNDLE_ID가 local.properties에 없음")
+
+private val appBundleIdDev =
+    getLocalProperty("APP_BUNDLE_ID_DEV") ?: error("APP_BUNDLE_ID_DEV가 local.properties에 없음")
+
+private val buildFlavor =
+    project.properties["buildkonfig.flavor"].toString()
+
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -45,6 +55,7 @@ plugins {
     alias(libs.plugins.mokkery)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.kotlinCocoapods)
+    alias(libs.plugins.firebaseCrashlytcis)
 }
 
 kotlin {
@@ -57,6 +68,8 @@ kotlin {
         ios.deploymentTarget = "17.0"
 
         pod("NMapsMap")
+        pod("FirebaseCrashlytics")
+        pod("FirebaseAnalytics")
     }
     androidTarget {
         compilerOptions {
@@ -84,6 +97,9 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.kotlinx.coroutines.android)
             implementation(libs.androidx.appcompat)
+            implementation(project.dependencies.platform(libs.firebase.bom))
+            implementation(libs.firebase.crashlytics.ndk)
+            implementation(libs.firebase.analytics)
         }
         commonMain.dependencies {
             implementation(libs.compose.navigationevent)
@@ -123,17 +139,21 @@ buildkonfig {
     packageName = "com.daedan.festabook"
 
     defaultConfigs {
+        buildConfigField(STRING, "BUILD_FLAVOR", buildFlavor)
         buildConfigField(STRING, "NAVER_MAP_STYLE_ID", naverMapStyleId)
         buildConfigField(STRING, "NAVER_MAP_CLIENT_ID", naverMapClientId)
         buildConfigField(STRING, "FESTABOOK_URL", baseUrlDev)
         buildConfigField(STRING, "FESTABOOK_IMAGE_URL", baseImageUrlDev)
+        buildConfigField(STRING, "APP_BUNDLE_ID", appBundleIdDev)
     }
 
     defaultConfigs("release") {
+        buildConfigField(STRING, "BUILD_FLAVOR", buildFlavor)
         buildConfigField(STRING, "NAVER_MAP_STYLE_ID", naverMapStyleId)
         buildConfigField(STRING, "NAVER_MAP_CLIENT_ID", naverMapClientId)
         buildConfigField(STRING, "FESTABOOK_URL", baseUrl)
         buildConfigField(STRING, "FESTABOOK_IMAGE_URL", baseImageUrl)
+        buildConfigField(STRING, "APP_BUNDLE_ID", appBundleId)
     }
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -56,6 +56,7 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.firebaseCrashlytcis)
+    alias(libs.plugins.google.gms.services)
 }
 
 kotlin {

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.android.kt
@@ -1,0 +1,25 @@
+package com.daedan.festabook.logging
+
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
+import kotlinx.coroutines.tasks.await
+
+actual object FirebaseAnalytics {
+    private val platform = Firebase.analytics
+
+    actual fun logEvent(
+        name: String,
+        params: Map<String, Any?>?,
+    ) {
+        platform.logEvent(name) {
+            params?.forEach {
+                param(it.key, it.value.toString())
+            }
+        }
+    }
+
+    actual suspend fun getAppInstanceId(): String = platform.appInstanceId.await()
+
+    actual suspend fun getSessionId(): Long = platform.sessionId.await()
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.android.kt
@@ -14,7 +14,12 @@ actual object FirebaseAnalytics {
     ) {
         platform.logEvent(name) {
             params?.forEach {
-                param(it.key, it.value.toString())
+                when (val v = it.value) {
+                    is Long -> param(it.key, v)
+                    is Double -> param(it.key, v)
+                    is String -> param(it.key, v)
+                    else -> param(it.key, v.toString())
+                }
             }
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.android.kt
@@ -1,0 +1,15 @@
+package com.daedan.festabook.logging
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics as PlatformFirebaseCrashlytics
+
+actual object FirebaseCrashlytics {
+    private val platform: PlatformFirebaseCrashlytics = PlatformFirebaseCrashlytics.getInstance()
+
+    actual fun recordException(throwable: Throwable) {
+        platform.recordException(throwable)
+    }
+
+    actual fun sendUnsentReports() {
+        platform.sendUnsentReports()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.kt
@@ -1,0 +1,12 @@
+package com.daedan.festabook.logging
+
+expect object FirebaseAnalytics {
+    fun logEvent(
+        name: String,
+        params: Map<String, Any?>? = null,
+    )
+
+    suspend fun getAppInstanceId(): String
+
+    suspend fun getSessionId(): Long
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.kt
@@ -1,0 +1,7 @@
+package com.daedan.festabook.logging
+
+expect object FirebaseCrashlytics {
+    fun recordException(throwable: Throwable)
+
+    fun sendUnsentReports()
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.ios.kt
@@ -9,13 +9,14 @@ actual object FirebaseAnalytics {
     private val platform = FIRAnalytics
     private const val KEY_UNINITIALIZED_USER_ID = "undefined"
 
+    @Suppress("UNCHECKED_CAST")
     actual fun logEvent(
         name: String,
         params: Map<String, Any?>?,
     ) {
         platform.logEventWithName(
             name,
-            params?.mapKeys { it.key as Any? },
+            params as? Map<Any?, Any?>,
         )
     }
 
@@ -23,8 +24,12 @@ actual object FirebaseAnalytics {
 
     actual suspend fun getSessionId(): Long =
         suspendCancellableCoroutine { cont ->
-            platform.sessionIDWithCompletion { id, _ ->
-                cont.resumeWith(Result.success(id))
+            platform.sessionIDWithCompletion { id, error ->
+                if (error != null) {
+                    cont.resumeWith(Result.failure(RuntimeException(error.localizedDescription)))
+                } else {
+                    cont.resumeWith(Result.success(id))
+                }
             }
         }
 }

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseAnalytics.ios.kt
@@ -1,0 +1,30 @@
+package com.daedan.festabook.logging
+
+import cocoapods.FirebaseAnalytics.FIRAnalytics
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+@OptIn(ExperimentalForeignApi::class)
+actual object FirebaseAnalytics {
+    private val platform = FIRAnalytics
+    private const val KEY_UNINITIALIZED_USER_ID = "undefined"
+
+    actual fun logEvent(
+        name: String,
+        params: Map<String, Any?>?,
+    ) {
+        platform.logEventWithName(
+            name,
+            params?.mapKeys { it.key as Any? },
+        )
+    }
+
+    actual suspend fun getAppInstanceId(): String = platform.appInstanceID() ?: KEY_UNINITIALIZED_USER_ID
+
+    actual suspend fun getSessionId(): Long =
+        suspendCancellableCoroutine { cont ->
+            platform.sessionIDWithCompletion { id, _ ->
+                cont.resumeWith(Result.success(id))
+            }
+        }
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.ios.kt
@@ -19,7 +19,7 @@ actual object FirebaseCrashlytics {
     }
 }
 
-fun Throwable.asNSError(): NSError {
+private fun Throwable.asNSError(): NSError {
     val userInfo = mutableMapOf<Any?, Any?>()
 
     message?.let {

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/logging/FirebaseCrashlytics.ios.kt
@@ -1,0 +1,35 @@
+package com.daedan.festabook.logging
+
+import cocoapods.FirebaseCrashlytics.FIRCrashlytics
+import com.daedan.festabook.BuildKonfig
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSError
+import platform.Foundation.NSLocalizedDescriptionKey
+
+@OptIn(ExperimentalForeignApi::class)
+actual object FirebaseCrashlytics {
+    private val platform = FIRCrashlytics.crashlytics()
+
+    actual fun recordException(throwable: Throwable) {
+        platform.recordError(throwable.asNSError())
+    }
+
+    actual fun sendUnsentReports() {
+        platform.sendUnsentReports()
+    }
+}
+
+fun Throwable.asNSError(): NSError {
+    val userInfo = mutableMapOf<Any?, Any?>()
+
+    message?.let {
+        userInfo[NSLocalizedDescriptionKey] = it
+    }
+
+    userInfo["KotlinStackTrace"] = stackTraceToString()
+    return NSError(
+        domain = BuildKonfig.APP_BUNDLE_ID,
+        code = 0,
+        userInfo = userInfo,
+    )
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/splash/platform/AppVersionManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/splash/platform/AppVersionManager.ios.kt
@@ -1,5 +1,6 @@
 package com.daedan.festabook.presentation.splash.platform
 
+import com.daedan.festabook.BuildKonfig
 import com.daedan.festabook.domain.repository.AppVersionRepository
 import dev.zacsweers.metro.Inject
 import platform.Foundation.NSBundle
@@ -15,7 +16,8 @@ actual class AppVersionManager(
         NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as? String
 
     actual suspend fun getIsAppUpdateAvailable(): Result<Boolean> {
-        val latestVersion = appVersionRepository.getLatestVersion(APP_BUNDLE_ID)
+        if (BuildKonfig.BUILD_FLAVOR == "dev") return Result.success(false)
+        val latestVersion = appVersionRepository.getLatestVersion(BuildKonfig.APP_BUNDLE_ID)
         return latestVersion.map { latest ->
             isNewerVersion(latest, currentAppVersion)
         }
@@ -62,7 +64,5 @@ actual class AppVersionManager(
         private const val APP_STORE_URL =
             "itms-apps://itunes.apple.com/app/apple-store/id/$APPLE_ID"
         private const val APP_STORE_WEB_URL = "https://apps.apple.com/app/id/$APPLE_ID"
-
-        private const val APP_BUNDLE_ID = "eoehdeksruf.festabook"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ landscapistCoil3 = "2.9.5"
 mapSdk = "3.22.1"
 playServicesLocation = "21.3.0"
 composeNavigationEvent = "1.0.1"
+crashlytics = "3.0.6"
+firebaseBom = "34.0.0"
 
 [libraries]
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastorePreferences" }
@@ -67,6 +69,11 @@ compottie = { module = "io.github.alexzhirkevich:compottie", version.ref = "comp
 ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlintVersion" }
 metrox-viewmodel-compose = { module = "dev.zacsweers.metro:metrox-viewmodel-compose", version.ref = "metro" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+
+
 
 map-sdk = { module = "com.naver.maps:map-sdk", version.ref = "mapSdk" }
 
@@ -84,3 +91,4 @@ metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
+firebaseCrashlytcis = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ playServicesLocation = "21.3.0"
 composeNavigationEvent = "1.0.1"
 crashlytics = "3.0.6"
 firebaseBom = "34.0.0"
+googleServices = "4.4.4"
 
 [libraries]
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastorePreferences" }
@@ -92,3 +93,4 @@ buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig"
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 firebaseCrashlytcis = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics"}
+google-gms-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -9,5 +9,7 @@ target 'iosApp' do
 
   # Pods for iosApp
   pod 'NMapsMap'
+  pod 'FirebaseCrashlytics'
+  pod 'FirebaseAnalytics'
 
 end

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,20 +1,167 @@
 PODS:
+  - FirebaseAnalytics (12.7.0):
+    - FirebaseAnalytics/Default (= 12.7.0)
+    - FirebaseCore (~> 12.7.0)
+    - FirebaseInstallations (~> 12.7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - FirebaseAnalytics/Default (12.7.0):
+    - FirebaseCore (~> 12.7.0)
+    - FirebaseInstallations (~> 12.7.0)
+    - GoogleAppMeasurement/Default (= 12.7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - FirebaseCore (12.7.0):
+    - FirebaseCoreInternal (~> 12.7.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreExtension (12.7.0):
+    - FirebaseCore (~> 12.7.0)
+  - FirebaseCoreInternal (12.7.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FirebaseCrashlytics (12.7.0):
+    - FirebaseCore (~> 12.7.0)
+    - FirebaseInstallations (~> 12.7.0)
+    - FirebaseRemoteConfigInterop (~> 12.7.0)
+    - FirebaseSessions (~> 12.7.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseInstallations (12.7.0):
+    - FirebaseCore (~> 12.7.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseRemoteConfigInterop (12.7.0)
+  - FirebaseSessions (12.7.0):
+    - FirebaseCore (~> 12.7.0)
+    - FirebaseCoreExtension (~> 12.7.0)
+    - FirebaseInstallations (~> 12.7.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+    - PromisesSwift (~> 2.1)
+  - GoogleAdsOnDeviceConversion (3.2.0):
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/Core (12.7.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/Default (12.7.0):
+    - GoogleAdsOnDeviceConversion (~> 3.2.0)
+    - GoogleAppMeasurement/Core (= 12.7.0)
+    - GoogleAppMeasurement/IdentitySupport (= 12.7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - GoogleAppMeasurement/IdentitySupport (12.7.0):
+    - GoogleAppMeasurement/Core (= 12.7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/Network (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+    - nanopb (~> 3.30910.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - NMapsGeometry (1.0.2)
   - NMapsMap (3.23.1):
     - NMapsGeometry
+  - PromisesObjC (2.4.0)
+  - PromisesSwift (2.4.0):
+    - PromisesObjC (= 2.4.0)
 
 DEPENDENCIES:
+  - FirebaseAnalytics
+  - FirebaseCrashlytics
   - NMapsMap
 
 SPEC REPOS:
   trunk:
+    - FirebaseAnalytics
+    - FirebaseCore
+    - FirebaseCoreExtension
+    - FirebaseCoreInternal
+    - FirebaseCrashlytics
+    - FirebaseInstallations
+    - FirebaseRemoteConfigInterop
+    - FirebaseSessions
+    - GoogleAdsOnDeviceConversion
+    - GoogleAppMeasurement
+    - GoogleDataTransport
+    - GoogleUtilities
+    - nanopb
     - NMapsGeometry
     - NMapsMap
+    - PromisesObjC
+    - PromisesSwift
 
 SPEC CHECKSUMS:
+  FirebaseAnalytics: e423129866107aeacf6010a280b9c9829f9ea50d
+  FirebaseCore: c7b57863ce0859281a66d16ca36d665c45d332b5
+  FirebaseCoreExtension: 731a5744970bcd73ad95ab2a2b8a1f46353e86dd
+  FirebaseCoreInternal: 571a2dd8c975410966199623351db3a3265c874d
+  FirebaseCrashlytics: 9ce9ce4bb179e31ab91a937d0a73d302a9752d1b
+  FirebaseInstallations: 6d05424a046b68ca146b4de4376f05b4e9262fc3
+  FirebaseRemoteConfigInterop: 0bae7d21510b3a0a79af727961c4973aac585add
+  FirebaseSessions: bc59e7d0ba90f96f40325fd1defbdec86ba26f20
+  GoogleAdsOnDeviceConversion: d68c69dd9581a0f5da02617b6f377e5be483970f
+  GoogleAppMeasurement: 8f59e08efecfa1bcd57f0a56fab07d079366268c
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
   NMapsMap: b4272a60dcbb8bccb206c632a133cae27a160031
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
 
-PODFILE CHECKSUM: ff32aad0fb2ca36057f4e02d63988ef75ac8eeb7
+PODFILE CHECKSUM: 6a5bb667335a398cc3b70f78c63e6562bba25452
 
 COCOAPODS: 1.16.2

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -38,8 +38,6 @@
 		};
 		8E6C8D378651BF8144E66D20 /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
@@ -71,7 +69,6 @@
 				B8BCC787F9096E9D0A4FA367 /* Pods-iosApp.debug.xcconfig */,
 				715130B6FFE2A7B0E186B7B0 /* Pods-iosApp.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -107,6 +104,8 @@
 				3ED20EC5BFA21FC0E7D100C7 /* Frameworks */,
 				A504BDED7EC474099DAD9F64 /* Resources */,
 				20E523B2847A296CA11BAE04 /* [CP] Embed Pods Frameworks */,
+				67E4A4402F6D7E2800C3FBD6 /* Copy Google Service plist */,
+				67E4A4352F6D707D00C3FBD6 /* Inititialize Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -173,14 +172,59 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		67E4A4352F6D707D00C3FBD6 /* Inititialize Firebase Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\n",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}\n",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\n",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist\n",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)\n",
+			);
+			name = "Inititialize Firebase Crashlytics";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+		};
+		67E4A4402F6D7E2800C3FBD6 /* Copy Google Service plist */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Google Service plist";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nDEBUG_CONFIG_PATH=\"${SRCROOT}/iosApp/GoogleService-Info-DEBUG.plist\"\nRELEASE_CONFIG_PATH=\"${SRCROOT}/iosApp/GoogleService-Info-RELEASE.plist\"\n\n# 2. 앱이 실제로 참조하게 될 목적지 경로\nDESTINATION_PATH=\"${SRCROOT}/iosApp/GoogleService-Info.plist\"\n\n# 3. 빌드 구성(Configuration)에 따라 복사 실행\nif [ \"${CONFIGURATION}\" == \"Debug\" ]; then\n    echo \"복사 중: Debug용 Firebase 설정...\"\n    cp \"${DEBUG_CONFIG_PATH}\" \"${DESTINATION_PATH}\"\nelse\n    echo \"복사 중: Release용 Firebase 설정...\"\n    cp \"${RELEASE_CONFIG_PATH}\" \"${DESTINATION_PATH}\"\nfi\n";
 		};
 		C08EE85BEF61373E7C695D8C /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -245,11 +289,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -260,6 +306,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = eoehdeksruf.festabook.debug;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -338,6 +385,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -348,6 +396,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = eoehdeksruf.festabook;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "festabook(Debug)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -385,6 +386,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = festabook;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -1,0 +1,14 @@
+import FirebaseCore
+import ComposeApp
+import NMapsMap
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        FirebaseApp.configure()
+        NMFAuthManager.shared().ncpKeyId = NativeBuildKonfig.shared.NAVER_MAP_CLIENT_ID
+        return true
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>CADisableMinimumFrameDurationOnPhone</key>
-        <true />
-        <key>NSLocationWhenInUseUsageDescription</key>
-        <string>현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.</string>
-        <key>LSApplicationQueriesSchemes</key>
-        <array>
-            <string>itms-apps</string>
-        </array>
-    </dict>
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-apps</string>
+	</array>
+</dict>
 </plist>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,12 +1,10 @@
 import SwiftUI
-import ComposeApp
-import NMapsMap
+import FirebaseCore
 
 @main
 struct iOSApp: App {
-    init() {
-        NMFAuthManager.shared().ncpKeyId = NativeBuildKonfig.shared.NAVER_MAP_CLIENT_ID
-    }
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/kotlin-multiplatform/issues/79

<br>

## 🛠️ 작업 내용

- Firebase Analytics, Crashlytics를 마이그레이션 하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

1. appVersionManager를 릴리즈 빌드 시에만 동작하도록 변경하였습니다 (iosMain)
2. FirebaseAnalytics, Crashlytics를 플랫폼별로 추상화 했습니다. 이벤트 로깅 부분은 회의가 필요할 것 같아 보류했습니다.
3. Android 설정은 SettingScsreen과 충돌이 날 것 같아 아직 하지 않았습니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Firebase Crashlytics 기반 크래시 리포팅 추가
  * Firebase Analytics 기반 사용자 활동 수집 추가

* **개선 사항**
  * iOS 앱 초기화 흐름을 앱 델리게이트 기반으로 전환
  * 빌드 구성과 번들 식별자(개발/릴리스) 관리 강화 및 플랫폼별 초기화 통합

* **변경**
  * iOS의 위치 권한 설명 문자열 제거(권한 프롬프트 동작에 영향 가능)

* **유지보수**
  * 개발/릴리스용 GoogleService-Info plist 파일을 .gitignore에 추가하여 버전 관리에서 제외
<!-- end of auto-generated comment: release notes by coderabbit.ai -->