### PR TITLE
[Test] ViewModelTest 마이그레이션

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.data.datasource.remote.festival
 
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
+import com.daedan.festabook.data.model.response.festival.RegisteredFestivalNotificationResponse
 
 interface FestivalNotificationRemoteDataSource {
     suspend fun saveFestivalNotification(
@@ -10,4 +11,6 @@ interface FestivalNotificationRemoteDataSource {
     ): ApiResult<FestivalNotificationResponse>
 
     suspend fun deleteFestivalNotification(festivalNotificationId: Long): ApiResult<Unit>
+
+    suspend fun getFestivalNotification(deviceId: Long): ApiResult<List<RegisteredFestivalNotificationResponse>>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.daedan.festabook.data.datasource.remote.festival
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.request.FestivalNotificationRequest
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
+import com.daedan.festabook.data.model.response.festival.RegisteredFestivalNotificationResponse
 import com.daedan.festabook.data.service.FestivalNotificationService
 import com.daedan.festabook.data.service.platform.festivalNotificationPlatform
 import dev.zacsweers.metro.AppScope
@@ -29,5 +30,10 @@ class FestivalNotificationRemoteDataSourceImpl(
     override suspend fun deleteFestivalNotification(festivalNotificationId: Long): ApiResult<Unit> =
         ApiResult.toApiResult {
             festivalNotificationService.deleteFestivalNotification(festivalNotificationId)
+        }
+
+    override suspend fun getFestivalNotification(deviceId: Long): ApiResult<List<RegisteredFestivalNotificationResponse>> =
+        ApiResult.toApiResult {
+            festivalNotificationService.getFestivalNotification(deviceId)
         }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/RegisteredFestivalNotificationResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/festival/RegisteredFestivalNotificationResponse.kt
@@ -1,0 +1,16 @@
+package com.daedan.festabook.data.model.response.festival
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisteredFestivalNotificationResponse(
+    @SerialName("festivalNotificationId")
+    val festivalNotificationId: Long,
+    @SerialName("festivalId")
+    val festivalId: Long,
+    @SerialName("organizationName")
+    val organizationName: String,
+    @SerialName("festivalName")
+    val festivalName: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/FestivalNotificationRepositoryImpl.kt
@@ -78,6 +78,39 @@ class FestivalNotificationRepositoryImpl(
             }
     }
 
+    override suspend fun syncFestivalNotificationIsAllow(): Result<Boolean> {
+        val deviceId =
+            deviceLocalDataSource.getDeviceId().firstOrNull() ?: return Result.failure(
+                IllegalArgumentException(NO_DEVICE_ID_EXCEPTION),
+            )
+        val festivalId =
+            festivalLocalDataSource.getFestivalId().firstOrNull() ?: return Result.failure(
+                IllegalArgumentException(NO_FESTIVAL_ID_EXCEPTION),
+            )
+
+        return festivalNotificationRemoteDataSource
+            .getFestivalNotification(deviceId)
+            .toResult()
+            .mapCatching { response ->
+                val notificationId =
+                    response.find { it.festivalId == festivalId }?.festivalNotificationId
+                val isAllowed = notificationId != null
+                festivalNotificationLocalDataSource.saveFestivalNotificationIsAllowed(
+                    festivalId,
+                    isAllowed,
+                )
+                if (isAllowed) {
+                    festivalNotificationLocalDataSource.saveFestivalNotificationId(
+                        festivalId,
+                        notificationId,
+                    )
+                } else {
+                    festivalNotificationLocalDataSource.deleteFestivalNotificationId(festivalId)
+                }
+                isAllowed
+            }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getFestivalNotificationIsAllow(): Flow<Boolean> =
         festivalLocalDataSource.getFestivalId().flatMapLatest { festivalId ->
@@ -102,5 +135,12 @@ class FestivalNotificationRepositoryImpl(
                 isAllowed = isAllowed,
             )
         }
+    }
+
+    companion object {
+        private val NO_FESTIVAL_ID_EXCEPTION =
+            "${::FestivalNotificationRepositoryImpl.name}: FestivalId가 없습니다."
+        private val NO_DEVICE_ID_EXCEPTION =
+            "${::FestivalNotificationRepositoryImpl.name}: DeviceId가 없습니다."
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalNotificationService.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/FestivalNotificationService.kt
@@ -2,9 +2,11 @@ package com.daedan.festabook.data.service
 
 import com.daedan.festabook.data.model.request.FestivalNotificationRequest
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
+import com.daedan.festabook.data.model.response.festival.RegisteredFestivalNotificationResponse
 import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
+import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.Path
 
@@ -20,4 +22,9 @@ interface FestivalNotificationService {
     suspend fun deleteFestivalNotification(
         @Path("festivalNotificationId") id: Long,
     ): Response<Unit>
+
+    @GET("festivals/notifications/{deviceId}")
+    suspend fun getFestivalNotification(
+        @Path("deviceId") id: Long,
+    ): Response<List<RegisteredFestivalNotificationResponse>>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/FestivalNotificationRepository.kt
@@ -7,6 +7,8 @@ interface FestivalNotificationRepository {
 
     suspend fun deleteFestivalNotification(): Result<Unit>
 
+    suspend fun syncFestivalNotificationIsAllow(): Result<Boolean>
+
     fun getFestivalNotificationIsAllow(): Flow<Boolean>
 
     suspend fun saveFestivalNotificationIsAllow(isAllowed: Boolean): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/FilterEventHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/FilterEventHandler.kt
@@ -20,12 +20,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
+interface FilterEventHandler : EventHandler<FilterEvent, PlaceMapUiState> {
+    fun updatePlacesByTimeTag(timeTagId: Long)
+}
+
 @Inject
 @ContributesBinding(PlaceMapViewModelScope::class)
-class FilterEventHandler(
+class FilterEventHandlerImpl(
     private val context: EventHandlerContext,
 //    private val logger: DefaultFirebaseLogger,
-) : EventHandler<FilterEvent, PlaceMapUiState> {
+) : FilterEventHandler {
     override val uiState: StateFlow<PlaceMapUiState> = context.uiState
     override val onUpdateState = context.onUpdateState
 
@@ -78,12 +82,7 @@ class FilterEventHandler(
         }
     }
 
-    private fun unselectPlace() {
-        onUpdateState.invoke { it.copy(selectedPlace = LoadState.Empty) }
-        context.mapControlSideEffect.trySend(MapControlSideEffect.UnselectMarker)
-    }
-
-    fun updatePlacesByTimeTag(timeTagId: Long) {
+    override fun updatePlacesByTimeTag(timeTagId: Long) {
         val filteredPlaces =
             if (timeTagId == TimeTag.EMTPY_TIME_TAG_ID) {
                 context.cachedPlaces.value
@@ -94,6 +93,11 @@ class FilterEventHandler(
             it.copy(places = ListLoadState.Success(filteredPlaces))
         }
         context.onUpdateCachedPlace(filteredPlaces)
+    }
+
+    private fun unselectPlace() {
+        onUpdateState.invoke { it.copy(selectedPlace = LoadState.Empty) }
+        context.mapControlSideEffect.trySend(MapControlSideEffect.UnselectMarker)
     }
 
     private fun updatePlacesByCategories(category: List<PlaceCategoryUiModel>) {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlEventHandlerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/MapControlEventHandlerImpl.kt
@@ -13,12 +13,14 @@ import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+interface MapControlEventHandler : EventHandler<MapControlEvent, PlaceMapUiState>
+
 @Inject
 @ContributesBinding(PlaceMapViewModelScope::class)
-class MapControlEventHandler(
+class MapControlEventHandlerImpl(
     private val context: EventHandlerContext,
 //    private val logger: DefaultFirebaseLogger,
-) : EventHandler<MapControlEvent, PlaceMapUiState> {
+) : MapControlEventHandler {
     override val uiState: StateFlow<PlaceMapUiState> = context.uiState
     override val onUpdateState = context.onUpdateState
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandlerImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandlerImpl.kt
@@ -16,14 +16,16 @@ import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+interface SelectEventHandler : EventHandler<SelectEvent, PlaceMapUiState>
+
 @Inject
 @ContributesBinding(PlaceMapViewModelScope::class)
-class SelectEventHandler(
+class SelectEventHandlerImpl(
     private val context: EventHandlerContext,
     private val filterActionHandler: FilterEventHandler,
 //    private val logger: DefaultFirebaseLogger,
     private val placeDetailRepository: PlaceDetailRepository,
-) : EventHandler<SelectEvent, PlaceMapUiState> {
+) : SelectEventHandler {
     override val uiState: StateFlow<PlaceMapUiState> = context.uiState
     override val onUpdateState = context.onUpdateState
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -39,8 +39,10 @@ class SettingViewModel(
     init {
         viewModelScope.launch {
             festivalNotificationRepository
-                .getFestivalNotificationIsAllow()
-                .collect { _isAllowed.value = it }
+                .syncFestivalNotificationIsAllow()
+                .onSuccess {
+                    _isAllowed.emit(it)
+                }
         }
     }
 
@@ -76,6 +78,7 @@ class SettingViewModel(
         // Optimistic UI 적용, 요청 실패 시 원복
         viewModelScope.launch {
             saveNotificationIsAllowed(true)
+            updateNotificationIsAllowed(true)
 
             val result =
                 festivalNotificationRepository.saveFestivalNotification()
@@ -86,6 +89,7 @@ class SettingViewModel(
                 }.onFailure {
                     _error.emit(it)
                     saveNotificationIsAllowed(false)
+                    updateNotificationIsAllowed(false)
 //                    Timber.e(it, "${this::class.java.simpleName} NotificationId 저장 실패")
                 }.also {
                     _isLoading.value = false
@@ -100,6 +104,7 @@ class SettingViewModel(
         // Optimistic UI 적용, 요청 실패 시 원복
         viewModelScope.launch {
             saveNotificationIsAllowed(false)
+            updateNotificationIsAllowed(false)
             val result =
                 festivalNotificationRepository.deleteFestivalNotification()
 
@@ -107,6 +112,7 @@ class SettingViewModel(
                 .onFailure {
                     _error.emit(it)
                     saveNotificationIsAllowed(true)
+                    updateNotificationIsAllowed(true)
 //                    Timber.e(it, "${this::class.java.simpleName} NotificationId 삭제 실패")
                 }.also {
                     _isLoading.value = false

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/FlowExtensions.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/FlowExtensions.kt
@@ -1,0 +1,41 @@
+package com.daedan.festabook
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.timeout
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+fun <T> TestScope.observeEvent(flow: Flow<T>): Deferred<T> {
+    val event =
+        backgroundScope.async {
+            withTimeout(3000) {
+                flow.first()
+            }
+        }
+    advanceUntilIdle()
+    return event
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+fun <T> TestScope.observeMultipleEvent(
+    flow: Flow<T>,
+    result: MutableList<T>,
+) {
+    backgroundScope.launch(UnconfinedTestDispatcher()) {
+        flow
+            .timeout(3.seconds)
+            .collect {
+                result.add(it)
+            }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/explore/ExploreViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/explore/ExploreViewModelTest.kt
@@ -1,0 +1,193 @@
+package com.daedan.festabook.explore
+
+import com.daedan.festabook.domain.model.FestivalSearchItem
+import com.daedan.festabook.domain.repository.ExploreRepository
+import com.daedan.festabook.presentation.explore.ExploreSideEffect
+import com.daedan.festabook.presentation.explore.ExploreViewModel
+import com.daedan.festabook.presentation.explore.SearchUiState
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.explore.model.toUiModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExploreViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var exploreRepository: ExploreRepository
+    private lateinit var exploreViewModel: ExploreViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        exploreRepository = mock(MockMode.autofill)
+        everySuspend { exploreRepository.search(any()) } returns Result.success(emptyList())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `뷰모델을 생성하면 저장된 축제 id가 있는지 확인한다`() =
+        runTest {
+            // given
+            everySuspend { exploreRepository.getFestivalId() } returns 1L
+
+            // when
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            advanceUntilIdle()
+
+            // then
+            verifySuspend { exploreRepository.getFestivalId() }
+            assertTrue(exploreViewModel.uiState.value.hasFestivalId)
+        }
+
+    @Test
+    fun `검색어가 변경되면 query 상태가 업데이트된다`() =
+        runTest {
+            // given
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            val query = "테스트"
+
+            // when
+            exploreViewModel.onTextInputChanged(query)
+            advanceUntilIdle()
+
+            // then
+            assertEquals(query, exploreViewModel.uiState.value.query)
+        }
+
+    @Test
+    fun `검색어가 변경되고 일정 시간이 지나면 검색을 수행하고 성공 시 결과를 업데이트한다`() =
+        runTest {
+            // given
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            val query = "테스트"
+            val universities =
+                listOf(
+                    FestivalSearchItem(
+                        festivalId = 1L,
+                        organizationName = "테스트대학교",
+                        festivalName = "테스트축제",
+                        startDate = "2024-05-01",
+                        endDate = "2024-05-03",
+                    ),
+                    FestivalSearchItem(
+                        festivalId = 2L,
+                        organizationName = "테스트대학교2",
+                        festivalName = "테스트축제2",
+                        startDate = "2024-09-01",
+                        endDate = "2024-09-03",
+                    ),
+                )
+            val uiModels = universities.map { it.toUiModel() }
+
+            everySuspend { exploreRepository.search(query) } returns Result.success(universities)
+
+            // when
+            exploreViewModel.onTextInputChanged(query)
+            advanceTimeBy(500L)
+            advanceUntilIdle()
+
+            // then
+            verifySuspend { exploreRepository.search(query) }
+            val searchState = exploreViewModel.uiState.value.searchState
+            assertIs<SearchUiState.Success>(searchState)
+            assertEquals(uiModels, searchState.universitiesFound)
+        }
+
+    @Test
+    fun `검색어가 비어있으면 Idle 상태로 변경된다`() =
+        runTest {
+            // given
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            exploreViewModel.onTextInputChanged("이전검색어")
+            advanceTimeBy(500L)
+            advanceUntilIdle()
+
+            // when
+            exploreViewModel.onTextInputChanged("")
+            advanceTimeBy(500L)
+            advanceUntilIdle()
+
+            // then
+            assertEquals(SearchUiState.Idle, exploreViewModel.uiState.value.searchState)
+        }
+
+    @Test
+    fun `검색 실패 시 Error 상태로 업데이트된다`() =
+        runTest {
+            // given
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            val query = "에러발생"
+            val exception = Exception("Network Error")
+            everySuspend { exploreRepository.search(query) } returns Result.failure(exception)
+
+            // when
+            exploreViewModel.onTextInputChanged(query)
+            advanceTimeBy(500L)
+            advanceUntilIdle()
+
+            // then
+            verifySuspend { exploreRepository.search(query) }
+            val searchState = exploreViewModel.uiState.value.searchState
+            assertIs<SearchUiState.Error>(searchState)
+            assertEquals(exception, searchState.throwable)
+        }
+
+    @Test
+    fun `대학교가 선택되었을 때 축제 Id를 저장하고 Main으로 이동하는 이벤트를 발생시킨다`() =
+        runTest {
+            // given
+            exploreViewModel = ExploreViewModel(exploreRepository)
+            val searchResult =
+                SearchResultUiModel(
+                    1L,
+                    "테스트대학교",
+                    "테스트축제",
+                )
+            val collectedSideEffects = mutableListOf<ExploreSideEffect>()
+
+            val job =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    exploreViewModel.sideEffect.collect {
+                        collectedSideEffects.add(it)
+                    }
+                }
+
+            // when
+            exploreViewModel.onUniversitySelected(searchResult)
+            advanceUntilIdle()
+
+            // then
+            verifySuspend { exploreRepository.saveFestivalId(searchResult.festivalId) }
+            assertEquals(1, collectedSideEffects.size)
+            assertEquals(
+                ExploreSideEffect.NavigateToMain(searchResult),
+                collectedSideEffects.first(),
+            )
+
+            job.cancel()
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeTestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeTestFixture.kt
@@ -1,0 +1,38 @@
+package com.daedan.festabook.home
+
+import com.daedan.festabook.domain.model.Festival
+import com.daedan.festabook.domain.model.LineupItem
+import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.domain.model.Poster
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+
+val FAKE_ORGANIZATION =
+    Organization(
+        id = 1,
+        organizationName = "하버드 대학교",
+        festival =
+            Festival(
+                festivalName = "하버드 대동제",
+                festivalImages =
+                    listOf(
+                        Poster(
+                            id = 1,
+                            imageUrl = "",
+                            sequence = 1,
+                        ),
+                    ),
+                startDate = LocalDate(2025, 1, 1),
+                endDate = LocalDate(2025, 1, 3),
+            ),
+    )
+
+val FAKE_LINEUP =
+    listOf(
+        LineupItem(
+            id = 1L,
+            imageUrl = "aa.com",
+            name = "SINGER",
+            performanceAt = LocalDateTime(2025, 9, 16, 0, 0, 0),
+        ),
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeViewModelTest.kt
@@ -1,0 +1,159 @@
+package com.daedan.festabook.home
+
+import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.presentation.home.FestivalUiState
+import com.daedan.festabook.presentation.home.HomeViewModel
+import com.daedan.festabook.presentation.home.LineUpItemOfDayUiModel
+import com.daedan.festabook.presentation.home.LineupUiState
+import com.daedan.festabook.presentation.home.toUiModel
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var homeViewModel: HomeViewModel
+    private lateinit var festivalRepository: FestivalRepository
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        festivalRepository = mock()
+        everySuspend { festivalRepository.getFestivalInfo() } returns
+            Result.success(
+                FAKE_ORGANIZATION,
+            )
+        everySuspend { festivalRepository.getLineUpGroupByDate() } returns
+            Result.success(
+                mapOf(
+                    FAKE_LINEUP[0].performanceAt.date to FAKE_LINEUP,
+                ),
+            )
+
+        homeViewModel = HomeViewModel(festivalRepository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `축제 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            val expect = FestivalUiState.Success(FAKE_ORGANIZATION)
+
+            // when
+            homeViewModel.loadFestival()
+            advanceUntilIdle()
+
+            // then
+            val actual = homeViewModel.festivalUiState.value
+            assertIs<FestivalUiState.Success>(actual)
+            assertEquals(expect, actual)
+        }
+
+    @Test
+    fun `연예인 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            val expectedLineup =
+                listOf(
+                    LineUpItemOfDayUiModel(
+                        id = 0,
+                        date = FAKE_LINEUP[0].performanceAt.date,
+                        isDDay = false,
+                        lineupItems = FAKE_LINEUP.map { it.toUiModel() },
+                    ),
+                )
+
+            // when
+            advanceUntilIdle()
+
+            // then
+            val actual = homeViewModel.lineupUiState.value
+            assertIs<LineupUiState.Success>(actual)
+
+            val actualItems = actual.lineups
+            assertEquals(expectedLineup.size, actualItems.size)
+            expectedLineup.zip(actualItems).forEach { (expected, actualItem) ->
+                assertEquals(expected.date, actualItem.date)
+                assertEquals(expected.isDDay, actualItem.isDDay)
+                assertEquals(expected.lineupItems, actualItem.lineupItems)
+            }
+        }
+
+    @Test
+    fun `축제 정보를 불러오는 동안은 Loading 상태로 전환한다`() =
+        runTest {
+            // given
+            val results = mutableListOf<FestivalUiState>()
+            val job =
+                launch(UnconfinedTestDispatcher()) {
+                    homeViewModel.festivalUiState.collect { results.add(it) }
+                }
+
+            // when
+            homeViewModel.loadFestival()
+
+            // then
+            testScheduler.runCurrent()
+            assertTrue(FestivalUiState.Loading in results)
+
+            advanceUntilIdle()
+            assertIs<FestivalUiState.Success>(results.last())
+
+            job.cancel()
+        }
+
+    @Test
+    fun `축제 정보를 불러오는 데 실패하면 Error 상태로 전환한다`() =
+        runTest {
+            // given
+            val exception = Throwable("Network Error")
+            everySuspend { festivalRepository.getFestivalInfo() } returns Result.failure(exception)
+
+            // when
+            homeViewModel.loadFestival()
+            advanceUntilIdle()
+
+            // then
+            assertIs<FestivalUiState.Error>(homeViewModel.festivalUiState.value)
+        }
+
+    @Test
+    fun `스케줄 이동 이벤트를 발생시킬 수 있다`() =
+        runTest {
+            // given
+            val events = mutableListOf<Unit>()
+            val job =
+                launch(UnconfinedTestDispatcher()) {
+                    homeViewModel.navigateToScheduleEvent.collect { events.add(it) }
+                }
+
+            // when
+            homeViewModel.navigateToScheduleClick()
+
+            // then
+            assertEquals(1, events.size)
+
+            job.cancel()
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/main/MainViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/main/MainViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.daedan.festabook.main
+
+import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.observeMultipleEvent
+import com.daedan.festabook.presentation.main.MainViewModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var festivalRepository: FestivalRepository
+    private lateinit var mainViewModel: MainViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        festivalRepository = mock(MockMode.autofill)
+        every { festivalRepository.getIsFirstVisit() } returns flowOf(false)
+        mainViewModel = MainViewModel(festivalRepository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `뒤로 가기를 두 번 빠르게 두 번 클릭했을 때 종료 이벤트가 발생한다`() =
+        runTest {
+            // given
+            val events = mutableListOf<Boolean>()
+            observeMultipleEvent(mainViewModel.backPressEvent, events)
+
+            // when
+            mainViewModel.onBackPressed()
+            mainViewModel.onBackPressed()
+            advanceUntilIdle()
+
+            // then
+            assertTrue(events.last())
+        }
+
+    @Test
+    fun `뒤로 가기를 한 번만 클릭했을 때 종료 이벤트가 발생하지 않는다`() =
+        runTest {
+            // given
+            val events = mutableListOf<Boolean>()
+            observeMultipleEvent(mainViewModel.backPressEvent, events)
+
+            // when
+            mainViewModel.onBackPressed()
+            advanceUntilIdle()
+
+            // then
+            assertFalse(events.last())
+        }
+
+    @Test
+    fun `축제 페이지의 첫 방문 여부를 확인할 수 있다`() =
+        runTest {
+            // given
+            every { festivalRepository.getIsFirstVisit() } returns flowOf(true)
+
+            // when
+            mainViewModel = MainViewModel(festivalRepository)
+            advanceUntilIdle()
+
+            // then
+            assertTrue(mainViewModel.isFirstVisit.value)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/news/NewsTestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/news/NewsTestFixture.kt
@@ -1,0 +1,59 @@
+package com.daedan.festabook.news
+
+import com.daedan.festabook.domain.model.FAQItem
+import com.daedan.festabook.domain.model.Lost
+import com.daedan.festabook.domain.model.LostItemStatus
+import com.daedan.festabook.domain.model.Notice
+import com.daedan.festabook.presentation.news.lost.model.toLostGuideItemUiModel
+import com.daedan.festabook.presentation.news.lost.model.toLostItemUiModel
+import kotlinx.datetime.LocalDateTime
+
+val FAKE_NOTICES =
+    listOf(
+        Notice(
+            id = 1,
+            title = "테스트 1",
+            content = "테스트 1",
+            isPinned = false,
+            createdAt = LocalDateTime(2025, 1, 1, 0, 0, 0),
+        ),
+        Notice(
+            id = 2,
+            title = "테스트 2",
+            content = "테스트 2",
+            isPinned = true,
+            createdAt = LocalDateTime(2025, 1, 1, 0, 0, 0),
+        ),
+    )
+
+val FAKE_FAQS =
+    listOf(
+        FAQItem(
+            questionId = 1,
+            question = "테스트 질문 1",
+            answer = "테스트 답변 1",
+            sequence = 1,
+        ),
+    )
+
+val FAKE_LOST_ITEM =
+    listOf(
+        Lost.Guide(
+            guide = "테스트 가이드",
+        ),
+        Lost.Item(
+            lostItemId = 1,
+            imageUrl = "테스트 이미지 주소",
+            storageLocation = "테스트 장소",
+            status = LostItemStatus.PENDING,
+            createdAt = LocalDateTime(2025, 1, 1, 0, 0, 0),
+        ),
+    )
+
+val FAKE_LOST_ITEM_UI_MODEL =
+    FAKE_LOST_ITEM.map {
+        when (it) {
+            is Lost.Guide -> it.toLostGuideItemUiModel()
+            is Lost.Item -> it.toLostItemUiModel()
+        }
+    }

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/news/NewsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/news/NewsViewModelTest.kt
@@ -1,0 +1,244 @@
+package com.daedan.festabook.news
+
+import com.daedan.festabook.domain.model.Lost
+import com.daedan.festabook.domain.repository.FAQRepository
+import com.daedan.festabook.domain.repository.LostItemRepository
+import com.daedan.festabook.domain.repository.NoticeRepository
+import com.daedan.festabook.presentation.news.NewsViewModel
+import com.daedan.festabook.presentation.news.faq.FAQUiState
+import com.daedan.festabook.presentation.news.faq.model.toUiModel
+import com.daedan.festabook.presentation.news.lost.LostUiState
+import com.daedan.festabook.presentation.news.lost.model.LostUiModel
+import com.daedan.festabook.presentation.news.lost.model.toLostGuideItemUiModel
+import com.daedan.festabook.presentation.news.lost.model.toLostItemUiModel
+import com.daedan.festabook.presentation.news.notice.NoticeUiState
+import com.daedan.festabook.presentation.news.notice.NoticeUiState.Companion.DEFAULT_POSITION
+import com.daedan.festabook.presentation.news.notice.model.NoticeUiModel
+import com.daedan.festabook.presentation.news.notice.model.toUiModel
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NewsViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var noticeRepository: NoticeRepository
+    private lateinit var faqRepository: FAQRepository
+    private lateinit var lostItemRepository: LostItemRepository
+    private lateinit var newsViewModel: NewsViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        noticeRepository = mock()
+        faqRepository = mock()
+        lostItemRepository = mock()
+        everySuspend { noticeRepository.fetchNotices() } returns Result.success(FAKE_NOTICES)
+        everySuspend { faqRepository.getAllFAQ() } returns Result.success(FAKE_FAQS)
+        everySuspend { lostItemRepository.getLost() } returns FAKE_LOST_ITEM
+
+        newsViewModel =
+            NewsViewModel(
+                noticeRepository,
+                faqRepository,
+                lostItemRepository,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `공지사항을 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { noticeRepository.fetchNotices() } returns Result.success(FAKE_NOTICES)
+
+            // when
+            newsViewModel.loadAllNotices(NoticeUiState(content = NoticeUiState.Content.InitialLoading))
+
+            // then
+            val expected = FAKE_NOTICES.map { it.toUiModel() }
+            val actual = newsViewModel.noticeUiState.value
+            verifySuspend { noticeRepository.fetchNotices() }
+            assertEquals(
+                NoticeUiState(content = NoticeUiState.Content.Success(expected, DEFAULT_POSITION)),
+                actual,
+            )
+        }
+
+    @Test
+    fun `분실물을 불러올 수 있다`() =
+        runTest {
+            // given
+            val expected =
+                LostUiState(
+                    content =
+                        LostUiState.Content.Success(
+                            listOf(
+                                (FAKE_LOST_ITEM[0] as Lost.Guide).toLostGuideItemUiModel(),
+                                (FAKE_LOST_ITEM[1] as Lost.Item).toLostItemUiModel(),
+                            ),
+                        ),
+                )
+
+            // when
+            newsViewModel.loadAllLostItems(LostUiState(content = LostUiState.Content.InitialLoading))
+
+            // then
+            val actual = newsViewModel.lostUiState.value
+            verifySuspend { lostItemRepository.getLost() }
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `공지사항 로드에 실패하면 에러 상태를 표시한다`() =
+        runTest {
+            // given
+            val exception = Throwable("테스트")
+            everySuspend { noticeRepository.fetchNotices() } returns Result.failure(exception)
+
+            // when
+            newsViewModel.loadAllNotices(NoticeUiState(content = NoticeUiState.Content.InitialLoading))
+
+            // then
+            val expected = NoticeUiState(content = NoticeUiState.Content.Error(exception))
+            val actual = newsViewModel.noticeUiState.value
+            verifySuspend { noticeRepository.fetchNotices() }
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `뷰모델을 생성하면 FAQ를 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { faqRepository.getAllFAQ() } returns Result.success(FAKE_FAQS)
+
+            // when
+            newsViewModel = NewsViewModel(noticeRepository, faqRepository, lostItemRepository)
+
+            // then
+            val expected = FAKE_FAQS.map { it.toUiModel() }
+            val actual = newsViewModel.faqUiState.value
+            verifySuspend { faqRepository.getAllFAQ() }
+            assertEquals(FAQUiState.Success(expected), actual)
+        }
+
+    @Test
+    fun `FAQ 로드에 실패하면 에러 상태를 표시한다`() =
+        runTest {
+            // given
+            val exception = Throwable("테스트")
+            everySuspend { faqRepository.getAllFAQ() } returns Result.failure(exception)
+
+            // when
+            newsViewModel = NewsViewModel(noticeRepository, faqRepository, lostItemRepository)
+
+            // then
+            val expected = FAQUiState.Error(exception)
+            val actual = newsViewModel.faqUiState.value
+            verifySuspend { faqRepository.getAllFAQ() }
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `공지사항 요소를 펼치게 할 수 있다`() =
+        runTest {
+            // given
+            val notice = FAKE_NOTICES.first().toUiModel()
+
+            // when
+            newsViewModel.toggleNotice(notice)
+
+            // then
+            val notices =
+                listOf(
+                    notice.copy(isExpanded = true),
+                    NoticeUiModel(
+                        id = 2,
+                        title = "테스트 2",
+                        content = "테스트 2",
+                        isPinned = true,
+                        createdAt = kotlinx.datetime.LocalDateTime(2025, 1, 1, 0, 0, 0),
+                    ),
+                )
+            val actual = newsViewModel.noticeUiState.value
+            val expected =
+                NoticeUiState(content = NoticeUiState.Content.Success(notices, DEFAULT_POSITION))
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `FAQ 요소를 펼치게 할 수 있다`() =
+        runTest {
+            // given
+            val faq = FAKE_FAQS.first().toUiModel()
+
+            // when
+            newsViewModel.toggleFAQ(faq)
+
+            // then
+            val expected = listOf(faq.copy(isExpanded = true))
+            val actual = newsViewModel.faqUiState.value
+            assertEquals(FAQUiState.Success(expected), actual)
+        }
+
+    @Test
+    fun `처음 로드했을 때 펼처질 공지사항을 지정할 수 있다`() =
+        runTest {
+            // given
+            everySuspend { noticeRepository.fetchNotices() } returns Result.success(FAKE_NOTICES)
+            val notices =
+                listOf(
+                    FAKE_NOTICES.first().toUiModel(),
+                    FAKE_NOTICES[1].toUiModel().copy(isExpanded = true),
+                )
+
+            // when
+            newsViewModel.expandNotice(2)
+
+            // then
+            val actual = newsViewModel.noticeUiState.value
+            val expected = NoticeUiState(content = NoticeUiState.Content.Success(notices, 1))
+            verifySuspend { noticeRepository.fetchNotices() }
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `분실물 가이드라인을 펼칠 수 있다`() =
+        runTest {
+            // given
+            val expected =
+                LostUiState(
+                    content =
+                        LostUiState.Content.Success(
+                            FAKE_LOST_ITEM_UI_MODEL.map {
+                                when (it) {
+                                    is LostUiModel.Guide -> it.copy(isExpanded = true)
+                                    else -> it
+                                }
+                            },
+                        ),
+                )
+
+            // when
+            newsViewModel.toggleLostGuide()
+
+            // then
+            val actual = newsViewModel.lostUiState.value
+            assertEquals(expected, actual)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailTestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailTestFixture.kt
@@ -1,0 +1,54 @@
+package com.daedan.festabook.placeDetail
+
+import com.daedan.festabook.domain.model.Place
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.domain.model.PlaceDetail
+import com.daedan.festabook.domain.model.PlaceDetailImage
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.news.FAKE_NOTICES
+import com.daedan.festabook.placeMap.FAKE_PLACES
+import kotlinx.datetime.LocalTime
+
+val FAKE_PLACE_DETAIL =
+    PlaceDetail(
+        id = 1,
+        place = FAKE_PLACES.first(),
+        notices = FAKE_NOTICES,
+        host = "테스트 1",
+        startTime = LocalTime(9, 0, 0),
+        endTime = LocalTime(18, 0, 0),
+        images =
+            listOf(
+                PlaceDetailImage(
+                    id = 1,
+                    imageUrl = "",
+                    sequence = 1,
+                ),
+            ),
+    )
+
+val FAKE_ETC_PLACE_DETAIL =
+    PlaceDetail(
+        id = 1,
+        place =
+            Place(
+                id = 1,
+                title = "화장실",
+                category = PlaceCategory.TOILET,
+                imageUrl = null,
+                description = null,
+                location = null,
+                timeTags =
+                    listOf(
+                        TimeTag(
+                            timeTagId = 1,
+                            name = "테스트1",
+                        ),
+                    ),
+            ),
+        notices = emptyList(),
+        host = null,
+        startTime = null,
+        endTime = null,
+        images = emptyList(),
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailViewModelTest.kt
@@ -91,7 +91,7 @@ class PlaceDetailViewModelTest {
         }
 
     @Test
-    fun `처음 뷰모델 생성 시, 플레이스 상세 정보가 있다면 서버에 요청하지 않는다`() =
+    fun `처음 뷰모델 생성 시에 플레이스 상세 정보가 있다면 서버에 요청하지 않는다`() =
         runTest {
             // given
             val expected = FAKE_PLACE_DETAIL.toUiModel()

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeDetail/PlaceDetailViewModelTest.kt
@@ -1,0 +1,139 @@
+package com.daedan.festabook.placeDetail
+
+import com.daedan.festabook.domain.repository.PlaceDetailRepository
+import com.daedan.festabook.news.FAKE_NOTICES
+import com.daedan.festabook.placeMap.FAKE_PLACES
+import com.daedan.festabook.presentation.news.notice.model.toUiModel
+import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
+import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiState
+import com.daedan.festabook.presentation.placeDetail.model.toUiModel
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaceDetailViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var placeDetailRepository: PlaceDetailRepository
+    private lateinit var placeDetailViewModel: PlaceDetailViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        placeDetailRepository = mock()
+        everySuspend { placeDetailRepository.getPlaceDetail(any()) } returns
+            Result.success(
+                FAKE_PLACE_DETAIL,
+            )
+        placeDetailViewModel =
+            PlaceDetailViewModel(placeDetailRepository, FAKE_PLACES.first().toUiModel(), null)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `플레이스 상세 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeDetailRepository.getPlaceDetail(any()) } returns
+                Result.success(
+                    FAKE_PLACE_DETAIL,
+                )
+
+            // when
+            placeDetailViewModel.loadPlaceDetail(1)
+            advanceUntilIdle()
+
+            // then
+            val expected = FAKE_PLACE_DETAIL.toUiModel()
+            val actual = placeDetailViewModel.placeDetail.value
+            verifySuspend { placeDetailRepository.getPlaceDetail(FAKE_PLACES.first().id) }
+            assertEquals(PlaceDetailUiState.Success(expected), actual)
+        }
+
+    @Test
+    fun `플레이스 상세 정보 로드에 실파하면 에러 상태를 표시한다`() =
+        runTest {
+            // given
+            val exception = Throwable("테스트")
+            everySuspend { placeDetailRepository.getPlaceDetail(any()) } returns Result.failure(exception)
+
+            // then
+            placeDetailViewModel.loadPlaceDetail(
+                placeId = 1,
+            )
+            advanceUntilIdle()
+
+            // then
+            val expected = PlaceDetailUiState.Error(exception)
+            val actual = placeDetailViewModel.placeDetail.value
+            verifySuspend { placeDetailRepository.getPlaceDetail(FAKE_PLACES.first().id) }
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `처음 뷰모델 생성 시, 플레이스 상세 정보가 있다면 서버에 요청하지 않는다`() =
+        runTest {
+            // given
+            val expected = FAKE_PLACE_DETAIL.toUiModel()
+            val placeDetailRepository = mock<PlaceDetailRepository>()
+
+            // when
+            placeDetailViewModel =
+                PlaceDetailViewModel(placeDetailRepository, null, expected)
+
+            // then
+            verifySuspend(VerifyMode.exactly(0)) { placeDetailRepository.getPlaceDetail(any()) }
+            val actual = placeDetailViewModel.placeDetail.value
+            assertEquals(
+                PlaceDetailUiState.Success(expected),
+                actual,
+            )
+        }
+
+    @Test
+    fun `플레이스 공지사항을 펼칠 수 있다`() =
+        runTest {
+            // given
+            val noticeItem = FAKE_NOTICES.first().toUiModel()
+            val expected =
+                listOf(
+                    noticeItem.copy(isExpanded = true),
+                    FAKE_NOTICES[1].toUiModel(),
+                )
+
+            // when
+            placeDetailViewModel.toggleNoticeExpanded(noticeItem)
+
+            // then
+            val actual =
+                placeDetailViewModel.placeDetail
+                    .value
+                    .let {
+                        (it as? PlaceDetailUiState.Success)
+                            ?: fail("PlaceDetailUiState 가 성공 상태가 아님")
+                    }.placeDetail
+                    .notices
+
+            assertEquals(expected, actual)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapTestFixture.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapTestFixture.kt
@@ -1,0 +1,178 @@
+package com.daedan.festabook.placeMap
+
+import com.daedan.festabook.domain.model.Coordinate
+import com.daedan.festabook.domain.model.OrganizationGeography
+import com.daedan.festabook.domain.model.Place
+import com.daedan.festabook.domain.model.PlaceCategory
+import com.daedan.festabook.domain.model.PlaceGeography
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.presentation.placeMap.model.CoordinateUiModel
+import com.daedan.festabook.presentation.placeMap.model.InitialMapSettingUiModel
+
+val FAKE_PLACES =
+    listOf(
+        Place(
+            id = 1,
+            imageUrl = null,
+            category = PlaceCategory.FOOD_TRUCK,
+            title = "테스트 1",
+            description = "설명 1",
+            location = "위치 1",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 1,
+                        name = "테스트1",
+                    ),
+                    TimeTag(
+                        timeTagId = 2,
+                        name = "테스트2",
+                    ),
+                ),
+        ),
+        Place(
+            id = 2,
+            imageUrl = null,
+            category = PlaceCategory.FOOD_TRUCK,
+            title = "테스트 2",
+            description = "설명 2",
+            location = "위치 2",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 2,
+                        name = "테스트2",
+                    ),
+                ),
+        ),
+    )
+
+val FAKE_PLACES_CATEGORY_FIXTURE =
+    listOf(
+        Place(
+            id = 1,
+            imageUrl = null,
+            category = PlaceCategory.FOOD_TRUCK,
+            title = "테스트 1",
+            description = "설명 1",
+            location = "위치 1",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 1,
+                        name = "테스트1",
+                    ),
+                    TimeTag(
+                        timeTagId = 2,
+                        name = "테스트2",
+                    ),
+                ),
+        ),
+        Place(
+            id = 2,
+            imageUrl = null,
+            category = PlaceCategory.BAR,
+            title = "테스트 2",
+            description = "설명 2",
+            location = "위치 2",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 2,
+                        name = "테스트2",
+                    ),
+                ),
+        ),
+    )
+
+val FAKE_PLACE_GEOGRAPHIES =
+    listOf(
+        PlaceGeography(
+            id = 1,
+            category = PlaceCategory.FOOD_TRUCK,
+            Coordinate(
+                latitude = 1.0,
+                longitude = 1.0,
+            ),
+            "푸드트럭",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 1,
+                        name = "테스트1",
+                    ),
+                ),
+        ),
+        PlaceGeography(
+            id = 1,
+            category = PlaceCategory.BOOTH,
+            Coordinate(
+                latitude = 1.0,
+                longitude = 1.0,
+            ),
+            "부스",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 1,
+                        name = "테스트1",
+                    ),
+                ),
+        ),
+        PlaceGeography(
+            id = 1,
+            category = PlaceCategory.BAR,
+            Coordinate(
+                latitude = 1.0,
+                longitude = 1.0,
+            ),
+            "주점",
+            timeTags =
+                listOf(
+                    TimeTag(
+                        timeTagId = 1,
+                        name = "테스트1",
+                    ),
+                ),
+        ),
+    )
+
+val FAKE_ORGANIZATION_GEOGRAPHY =
+    OrganizationGeography(
+        zoom = 15,
+        initialCenter =
+            Coordinate(
+                latitude = 1.0,
+                longitude = 1.0,
+            ),
+        polygonHoleBoundary =
+            listOf(
+                Coordinate(
+                    latitude = 1.0,
+                    longitude = 1.0,
+                ),
+            ),
+    )
+
+val FAKE_TIME_TAG =
+    TimeTag(
+        timeTagId = 1,
+        name = "테스트1",
+    )
+
+val FAKE_INITIAL_MAP_SETTING =
+    InitialMapSettingUiModel(
+        zoom = 10,
+        initialCenter =
+            CoordinateUiModel(
+                latitude = 10.0,
+                longitude = 10.0,
+            ),
+        border =
+            listOf(
+                CoordinateUiModel(
+                    latitude = 10.0,
+                    longitude = 10.0,
+                ),
+            ),
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
@@ -75,7 +75,7 @@ class PlaceMapViewModelTest {
     }
 
     @Test
-    fun `뷰모델을 생성했을 때 전체 타임태그, 선택된 타임태그를 불러올 수 있다`() =
+    fun `뷰모델을 생성했을 때 전체 타임태그와 선택된 타임태그를 불러올 수 있다`() =
         runTest {
             // given - when
             placeMapViewModel =

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
@@ -1,0 +1,286 @@
+package com.daedan.festabook.placeMap
+
+import com.daedan.festabook.di.placeMapHandler.PlaceMapHandlerGraph
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.domain.repository.PlaceListRepository
+import com.daedan.festabook.observeEvent
+import com.daedan.festabook.presentation.placeMap.PlaceMapViewModel
+import com.daedan.festabook.presentation.placeMap.intent.event.FilterEvent
+import com.daedan.festabook.presentation.placeMap.intent.event.MapControlEvent
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.ListLoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaceMapViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val handlerGraphFactory = mock<PlaceMapHandlerGraph.Factory>(MockMode.autofill)
+    private lateinit var placeListRepository: PlaceListRepository
+    private lateinit var placeMapViewModel: PlaceMapViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        placeListRepository = mock(MockMode.autofill)
+        everySuspend { placeListRepository.getPlaces() } returns Result.success(FAKE_PLACES)
+        everySuspend { placeListRepository.getPlaceGeographies() } returns
+            Result.success(
+                FAKE_PLACE_GEOGRAPHIES,
+            )
+        everySuspend { placeListRepository.getOrganizationGeography() } returns
+            Result.success(
+                FAKE_ORGANIZATION_GEOGRAPHY,
+            )
+        everySuspend { placeListRepository.getTimeTags() } returns
+            Result.success(
+                listOf(
+                    FAKE_TIME_TAG,
+                ),
+            )
+
+        placeMapViewModel =
+            PlaceMapViewModel(
+                placeListRepository,
+                handlerGraphFactory,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `뷰모델을 생성했을 때 전체 타임태그, 선택된 타임태그를 불러올 수 있다`() =
+        runTest {
+            // given - when
+            placeMapViewModel =
+                PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val uiState = placeMapViewModel.uiState.value
+            val actualAllTimeTag = uiState.timeTags
+            val actualSelectedTimeTag = uiState.selectedTimeTag
+            assertEquals(
+                LoadState.Success(listOf(FAKE_TIME_TAG)),
+                actualAllTimeTag,
+            )
+            assertEquals(
+                LoadState.Success(FAKE_TIME_TAG),
+                actualSelectedTimeTag,
+            )
+        }
+
+    @Test
+    fun `뷰모델을 생성했을 때 모든 플레이스 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeListRepository.getPlaces() } returns Result.success(FAKE_PLACES)
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val expected = FAKE_PLACES.map { it.toUiModel() }
+            val uiState = placeMapViewModel.uiState.value
+            val actual = uiState.places
+            verifySuspend { placeListRepository.getPlaces() }
+            assertEquals(ListLoadState.PlaceLoaded(expected), actual)
+        }
+
+    @Test
+    fun `뷰모델을 생성했을 때 타임 태그가 없다면 빈 리스트와 Empty타임 태그를 불러온다`() =
+        runTest {
+            // given
+            everySuspend {
+                placeListRepository.getTimeTags()
+            } returns Result.success(emptyList())
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val uiState = placeMapViewModel.uiState.value
+            val actualAllTimeTag = uiState.timeTags
+            val actualSelectedTimeTag = uiState.selectedTimeTag
+            assertEquals(
+                LoadState.Success(emptyList<TimeTag>()),
+                actualAllTimeTag,
+            )
+            assertEquals(LoadState.Empty, actualSelectedTimeTag)
+        }
+
+    @Test
+    fun `뷰모델을 생성했을 때 모든 플레이스의 지도 좌표 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeListRepository.getPlaceGeographies() } returns
+                Result.success(
+                    FAKE_PLACE_GEOGRAPHIES,
+                )
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val expected = FAKE_PLACE_GEOGRAPHIES.map { it.toUiModel() }
+            val uiState = placeMapViewModel.uiState.value
+            val actual = uiState.placeGeographies
+            verifySuspend { placeListRepository.getPlaceGeographies() }
+            assertEquals(LoadState.Success(expected), actual)
+        }
+
+    @Test
+    fun `뷰모델을 생성했을 때 초기 학교 지리 정보를 불러올 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeListRepository.getOrganizationGeography() } returns
+                Result.success(
+                    FAKE_ORGANIZATION_GEOGRAPHY,
+                )
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val expected = FAKE_ORGANIZATION_GEOGRAPHY.toUiModel()
+            val uiState = placeMapViewModel.uiState.value
+            val actual = uiState.initialMapSetting
+            assertEquals(LoadState.Success(expected), actual)
+        }
+
+    @Test
+    fun `뷰모델을 생성했을 때 정보 로드에 실패하면 독립적으로 에러 상태를 표시한다`() =
+        runTest {
+            // given
+            val exception = Throwable("테스트")
+            everySuspend { placeListRepository.getPlaces() } returns Result.failure(exception)
+            everySuspend { placeListRepository.getOrganizationGeography() } returns
+                Result.success(
+                    FAKE_ORGANIZATION_GEOGRAPHY,
+                )
+            everySuspend { placeListRepository.getPlaceGeographies() } returns Result.failure(exception)
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            advanceUntilIdle()
+
+            // then
+            val uiState = placeMapViewModel.uiState.value
+            assertEquals(LoadState.Success(FAKE_ORGANIZATION_GEOGRAPHY.toUiModel()), uiState.initialMapSetting)
+            assertEquals(LoadState.Error(exception), uiState.placeGeographies)
+        }
+
+    @Test
+    fun `특정 액션을 받으면 액션 핸들러가 호출된다`() =
+        runTest {
+            // given
+            val fakeHandlerGraph = mock<PlaceMapHandlerGraph>(MockMode.original)
+            every { fakeHandlerGraph.filterEventHandler } returns mock(MockMode.autofill)
+            every { fakeHandlerGraph.selectEventHandler } returns mock(MockMode.autofill)
+            every { fakeHandlerGraph.mapControlEventHandler } returns mock(MockMode.autofill)
+            every {
+                handlerGraphFactory.create(any())
+            } returns fakeHandlerGraph
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            placeMapViewModel.onPlaceMapEvent(SelectEvent.UnSelectPlace)
+            placeMapViewModel.onPlaceMapEvent(FilterEvent.OnPlaceLoad)
+            placeMapViewModel.onPlaceMapEvent(MapControlEvent.OnMapDrag)
+            advanceUntilIdle()
+
+            // then
+            verify(VerifyMode.exactly(1)) { fakeHandlerGraph.filterEventHandler }
+            verify(VerifyMode.exactly(1)) { fakeHandlerGraph.selectEventHandler }
+            verify(VerifyMode.exactly(1)) { fakeHandlerGraph.mapControlEventHandler }
+        }
+
+    @Test
+    fun `메뉴 아이템 재클릭 이벤트를 발송할 수 있다`() =
+        runTest {
+            // given
+            val event = observeEvent(placeMapViewModel.placeMapSideEffect)
+
+            // when
+            placeMapViewModel.onMenuItemReClicked()
+            val result = event.await()
+            advanceUntilIdle()
+
+            // then
+            assertIs<PlaceMapSideEffect.MenuItemReClicked>(result)
+        }
+
+    @Test
+    fun `LoadState가 하나라도 에러가 있다면 에러 이벤트를 발송할 수 있다`() =
+        runTest {
+            // given
+            val throwable = Throwable()
+            everySuspend { placeListRepository.getPlaceGeographies() } returns Result.failure(throwable)
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            val event = observeEvent(placeMapViewModel.placeMapSideEffect)
+            advanceUntilIdle()
+
+            // then
+            val result = event.await()
+            advanceUntilIdle()
+
+            assertEquals(
+                PlaceMapSideEffect.ShowErrorSnackBar(LoadState.Error(throwable)),
+                result,
+            )
+        }
+
+    @Test
+    fun `ListLoadState가 하나라도 에러가 있다면 에러 이벤트를 발송할 수 있다`() =
+        runTest {
+            // given
+            val throwable = Throwable()
+            everySuspend { placeListRepository.getPlaces() } returns Result.failure(throwable)
+
+            // when
+            placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
+            val event = observeEvent(placeMapViewModel.placeMapSideEffect)
+            advanceUntilIdle()
+
+            // then
+            val result = event.await()
+            advanceUntilIdle()
+
+            assertEquals(
+                PlaceMapSideEffect.ShowErrorSnackBar(LoadState.Error(throwable)),
+                result,
+            )
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/FilterActionHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/FilterActionHandlerTest.kt
@@ -1,0 +1,228 @@
+package com.daedan.festabook.placeMap.handler
+
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.observeMultipleEvent
+import com.daedan.festabook.placeMap.FAKE_PLACES_CATEGORY_FIXTURE
+import com.daedan.festabook.placeMap.FAKE_TIME_TAG
+import com.daedan.festabook.presentation.placeMap.intent.event.FilterEvent
+import com.daedan.festabook.presentation.placeMap.intent.handler.EventHandlerContext
+import com.daedan.festabook.presentation.placeMap.intent.handler.FilterEventHandlerImpl
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.ListLoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import com.daedan.festabook.presentation.placeMap.model.PlaceCategoryUiModel
+import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
+import com.daedan.festabook.presentation.placeMap.model.toUiModel
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FilterActionHandlerTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var filterActionHandler: FilterEventHandlerImpl
+
+    private lateinit var cachedPlaces: MutableStateFlow<List<PlaceUiModel>>
+
+    private lateinit var uiState: MutableStateFlow<PlaceMapUiState>
+
+    private val cachedPlaceByTimeTag =
+        MutableStateFlow(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+
+    private val mapControlUiEvent: Channel<MapControlSideEffect> =
+        Channel(
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        uiState = MutableStateFlow(PlaceMapUiState())
+        cachedPlaces = MutableStateFlow(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+
+        filterActionHandler =
+            FilterEventHandlerImpl(
+                EventHandlerContext(
+                    uiState = uiState,
+                    mapControlSideEffect = mapControlUiEvent,
+                    onUpdateState = { uiState.update(it) },
+                    onUpdateCachedPlace = { cachedPlaceByTimeTag.tryEmit(it) },
+                    cachedPlaces = cachedPlaces,
+                    cachedPlaceByTimeTag = cachedPlaceByTimeTag,
+                    scope = CoroutineScope(testDispatcher),
+                    placeMapSideEffect = mock(MockMode.autofill),
+                ),
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `선택된 카테고리 값을 선택하면 카테고리 필터 이벤트가 방출되고, 카테고리를 필터링 할 수 있다`() =
+        runTest {
+            // given
+            val categories = setOf(PlaceCategoryUiModel.BOOTH)
+            val eventResult = mutableListOf<MapControlSideEffect>()
+            observeMultipleEvent(mapControlUiEvent.consumeAsFlow(), eventResult)
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+
+            // when
+            filterActionHandler(FilterEvent.OnCategoryClick(categories))
+
+            // then
+            advanceUntilIdle()
+
+            assertEquals(categories, uiState.value.selectedCategories)
+
+            assertEquals(
+                listOf(
+                    MapControlSideEffect.UnselectMarker,
+                    MapControlSideEffect.FilterMapByCategory(categories.toList()),
+                ),
+                eventResult,
+            )
+            assertEquals(
+                ListLoadState.Success(emptyList<PlaceUiModel>()),
+                uiState.value.places,
+            )
+        }
+
+    @Test
+    fun `선택된 카테고리가 부스, 주점, 푸드트럭에 해당되지 않을 때 전체 목록을 불러온다`() =
+        runTest {
+            // given
+            val targetCategories =
+                setOf(PlaceCategoryUiModel.SMOKING_AREA, PlaceCategoryUiModel.TOILET)
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+
+            // when
+            filterActionHandler(FilterEvent.OnCategoryClick(targetCategories))
+            advanceUntilIdle()
+
+            // then
+            val expected =
+                ListLoadState.Success(
+                    FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() },
+                )
+            assertEquals(expected, uiState.value.places)
+        }
+
+    @Test
+    fun `기타 카테고리만 선택되었다면 전체 목록을 불러온다`() =
+        runTest {
+            // given
+            val targetCategories =
+                setOf(PlaceCategoryUiModel.TOILET, PlaceCategoryUiModel.SMOKING_AREA)
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+
+            // when
+            filterActionHandler(FilterEvent.OnCategoryClick(targetCategories))
+            advanceUntilIdle()
+
+            // then
+            val expected =
+                ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            assertEquals(expected, uiState.value.places)
+        }
+
+    @Test
+    fun `필터링을 해제하면 전체 목록을 반환한다`() =
+        runTest {
+            // given
+            val targetCategories =
+                setOf(PlaceCategoryUiModel.FOOD_TRUCK, PlaceCategoryUiModel.BOOTH)
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+            filterActionHandler(FilterEvent.OnCategoryClick(targetCategories))
+
+            // when
+            filterActionHandler(FilterEvent.OnCategoryClick(emptySet()))
+
+            // then
+            val expected = FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() }
+            assertEquals(ListLoadState.Success(expected), uiState.value.places)
+        }
+
+    @Test
+    fun `타임 태그를 기준으로 필터링 할 수 있다`() =
+        runTest {
+            // given
+            val expected =
+                listOf(
+                    FAKE_PLACES_CATEGORY_FIXTURE.first().toUiModel(),
+                )
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+
+            // when
+            filterActionHandler.updatePlacesByTimeTag(FAKE_TIME_TAG.timeTagId)
+
+            // then
+            assertEquals(ListLoadState.Success(expected), uiState.value.places)
+        }
+
+    @Test
+    fun `타임 태그가 없을 때 전체 목록을 반환한다`() =
+        runTest {
+            // given
+            val expected = FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() }
+            val emptyTimeTag = TimeTag.EMPTY
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update { it.copy(places = places) }
+
+            // when
+            filterActionHandler.updatePlacesByTimeTag(emptyTimeTag.timeTagId)
+            advanceUntilIdle()
+
+            // then
+            assertEquals(ListLoadState.Success(expected), uiState.value.places)
+        }
+
+    @Test
+    fun `플레이스가 로드가 완료되었을 때 선택된 타임 태그로 필터링할 수 있다`() =
+        runTest {
+            // given
+            val expected =
+                listOf(
+                    FAKE_PLACES_CATEGORY_FIXTURE.first().toUiModel(),
+                )
+            val places = ListLoadState.Success(FAKE_PLACES_CATEGORY_FIXTURE.map { it.toUiModel() })
+            uiState.update {
+                it.copy(
+                    places = places,
+                    selectedTimeTag = LoadState.Success(FAKE_TIME_TAG),
+                )
+            }
+
+            // when
+            filterActionHandler(FilterEvent.OnPlaceLoad)
+            advanceUntilIdle()
+
+            // then
+            assertEquals(ListLoadState.Success(expected), uiState.value.places)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/FilterActionHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/FilterActionHandlerTest.kt
@@ -79,7 +79,7 @@ class FilterActionHandlerTest {
     }
 
     @Test
-    fun `선택된 카테고리 값을 선택하면 카테고리 필터 이벤트가 방출되고, 카테고리를 필터링 할 수 있다`() =
+    fun `선택된 카테고리 값을 선택하면 카테고리 필터 이벤트가 방출되고 카테고리를 필터링 할 수 있다`() =
         runTest {
             // given
             val categories = setOf(PlaceCategoryUiModel.BOOTH)
@@ -110,7 +110,7 @@ class FilterActionHandlerTest {
         }
 
     @Test
-    fun `선택된 카테고리가 부스, 주점, 푸드트럭에 해당되지 않을 때 전체 목록을 불러온다`() =
+    fun `선택된 카테고리가 부스 주점 푸드트럭에 해당되지 않을 때 전체 목록을 불러온다`() =
         runTest {
             // given
             val targetCategories =

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/MapEventActionHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/MapEventActionHandlerTest.kt
@@ -1,0 +1,163 @@
+package com.daedan.festabook.placeMap.handler
+
+import com.daedan.festabook.observeEvent
+import com.daedan.festabook.observeMultipleEvent
+import com.daedan.festabook.placeMap.FAKE_INITIAL_MAP_SETTING
+import com.daedan.festabook.presentation.placeMap.intent.event.MapControlEvent
+import com.daedan.festabook.presentation.placeMap.intent.handler.EventHandlerContext
+import com.daedan.festabook.presentation.placeMap.intent.handler.MapControlEventHandlerImpl
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapEventActionHandlerTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var mapEventActionHandler: MapControlEventHandlerImpl
+
+    private lateinit var uiState: MutableStateFlow<PlaceMapUiState>
+
+    private val mapControlUiEvent: Channel<MapControlSideEffect> =
+        Channel(
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    private val placeMapUiEvent: Channel<PlaceMapSideEffect> =
+        Channel(
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        uiState = MutableStateFlow(PlaceMapUiState())
+        mapEventActionHandler =
+            MapControlEventHandlerImpl(
+                EventHandlerContext(
+                    uiState = uiState,
+                    onUpdateState = { uiState.update(it) },
+                    mapControlSideEffect = mapControlUiEvent,
+                    placeMapSideEffect = placeMapUiEvent,
+                    scope = CoroutineScope(testDispatcher),
+                    cachedPlaces = MutableStateFlow(emptyList()),
+                    cachedPlaceByTimeTag = MutableStateFlow(emptyList()),
+                    onUpdateCachedPlace = {},
+                ),
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `초기 위치로 돌아가기 버튼 클릭 시 이벤트가 방출된다`() =
+        runTest {
+            // given
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+            advanceUntilIdle()
+
+            // when
+            mapEventActionHandler(MapControlEvent.OnBackToInitialPositionClick)
+
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            // then
+            assertEquals(MapControlSideEffect.BackToInitialPosition, event)
+        }
+
+    @Test
+    fun `지도가 준비되었을 때 지도 관련 로직 초기화 이벤트를 방출할 수 있다`() =
+        runTest {
+            // given
+            val eventResult = mutableListOf<MapControlSideEffect>()
+            observeMultipleEvent(mapControlUiEvent.receiveAsFlow(), eventResult)
+
+            val initialSetting = FAKE_INITIAL_MAP_SETTING
+            uiState.update {
+                it.copy(initialMapSetting = LoadState.Success(initialSetting))
+            }
+
+            // when
+            mapEventActionHandler(MapControlEvent.OnMapReady)
+            advanceUntilIdle()
+
+            // then
+            assertEquals(
+                listOf(
+                    MapControlSideEffect.InitMap,
+                    MapControlSideEffect.InitMapManager(initialSetting),
+                ),
+                eventResult,
+            )
+        }
+
+    @Test
+    fun `플레이스 로딩이 완료되었을 때 프리로드 이미지 이벤트를 방출할 수 있다`() =
+        runTest {
+            // given
+            val eventResult = observeEvent(placeMapUiEvent.receiveAsFlow())
+            advanceUntilIdle()
+
+            // when
+            mapEventActionHandler(MapControlEvent.OnPlaceLoadFinish(emptyList()))
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+            assertEquals(PlaceMapSideEffect.PreloadImages(emptyList()), event)
+        }
+
+    @Test
+    fun `초기 위치로 돌아갔을 때 방출할 수 있다`() =
+        runTest {
+            // given
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+            advanceUntilIdle()
+
+            // when
+            mapEventActionHandler(MapControlEvent.OnBackToInitialPositionClick)
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            // then
+            assertEquals(MapControlSideEffect.BackToInitialPosition, event)
+        }
+
+    @Test
+    fun `지도가 드래그 되었을 때 이벤트를 방출할 수 있다`() =
+        runTest {
+            // given
+            val eventResult = observeEvent(placeMapUiEvent.receiveAsFlow())
+            advanceUntilIdle()
+
+            // when
+            mapEventActionHandler(MapControlEvent.OnMapDrag)
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            assertEquals(PlaceMapSideEffect.MapViewDrag(false), event)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/SelectActionHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/SelectActionHandlerTest.kt
@@ -1,0 +1,232 @@
+package com.daedan.festabook.placeMap.handler
+
+import com.daedan.festabook.domain.model.TimeTag
+import com.daedan.festabook.domain.repository.PlaceDetailRepository
+import com.daedan.festabook.observeEvent
+import com.daedan.festabook.placeDetail.FAKE_ETC_PLACE_DETAIL
+import com.daedan.festabook.placeDetail.FAKE_PLACE_DETAIL
+import com.daedan.festabook.placeMap.FAKE_TIME_TAG
+import com.daedan.festabook.presentation.placeDetail.model.toUiModel
+import com.daedan.festabook.presentation.placeMap.intent.event.SelectEvent
+import com.daedan.festabook.presentation.placeMap.intent.handler.EventHandlerContext
+import com.daedan.festabook.presentation.placeMap.intent.handler.SelectEventHandlerImpl
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.MapControlSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.sideEffect.PlaceMapSideEffect
+import com.daedan.festabook.presentation.placeMap.intent.state.LoadState
+import com.daedan.festabook.presentation.placeMap.intent.state.PlaceMapUiState
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SelectActionHandlerTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var selectActionHandler: SelectEventHandlerImpl
+
+    private lateinit var uiState: MutableStateFlow<PlaceMapUiState>
+
+    private lateinit var placeDetailRepository: PlaceDetailRepository
+
+    private val mapControlUiEvent: Channel<MapControlSideEffect> =
+        Channel(
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    private val placeMapUiEvent: Channel<PlaceMapSideEffect> =
+        Channel(
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        placeDetailRepository = mock()
+        uiState = MutableStateFlow(PlaceMapUiState())
+
+        selectActionHandler =
+            SelectEventHandlerImpl(
+                EventHandlerContext(
+                    mapControlSideEffect = mapControlUiEvent,
+                    placeMapSideEffect = placeMapUiEvent,
+                    uiState = uiState,
+                    onUpdateState = { uiState.update(it) },
+                    scope = CoroutineScope(testDispatcher),
+                    cachedPlaces = MutableStateFlow(emptyList()),
+                    cachedPlaceByTimeTag = MutableStateFlow(emptyList()),
+                    onUpdateCachedPlace = {},
+                ),
+                filterActionHandler = mock(MockMode.autofill),
+                placeDetailRepository = placeDetailRepository,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `플레이스의 아이디와 카테고리가 있으면 플레이스 상세를 선택할 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeDetailRepository.getPlaceDetail(1) } returns
+                Result.success(
+                    FAKE_PLACE_DETAIL,
+                )
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+
+            // when
+            selectActionHandler(SelectEvent.OnPlaceClick(1))
+            advanceUntilIdle()
+
+            // then
+            verifySuspend { placeDetailRepository.getPlaceDetail(1) }
+
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            val expected = LoadState.Success(FAKE_PLACE_DETAIL.toUiModel())
+            assertEquals(expected, uiState.value.selectedPlace)
+            assertEquals(MapControlSideEffect.SelectMarker(expected), event)
+        }
+
+    @Test
+    fun `카테고리가 기타시설일 떄에도 플레이스 상세를 선택할 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeDetailRepository.getPlaceDetail(1) } returns
+                Result.success(
+                    FAKE_ETC_PLACE_DETAIL,
+                )
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+
+            // when
+            selectActionHandler(SelectEvent.OnPlaceClick(1))
+            advanceUntilIdle()
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            val expected = LoadState.Success(FAKE_ETC_PLACE_DETAIL.toUiModel())
+            assertEquals(expected, uiState.value.selectedPlace)
+            assertEquals(MapControlSideEffect.SelectMarker(expected), event)
+        }
+
+    @Test
+    fun `플레이스 상세 선택을 해제할 수 있다`() =
+        runTest {
+            // given
+            everySuspend { placeDetailRepository.getPlaceDetail(1) } returns
+                Result.success(
+                    FAKE_PLACE_DETAIL,
+                )
+            selectActionHandler(SelectEvent.OnPlaceClick(1))
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+            advanceUntilIdle()
+
+            // when
+            selectActionHandler(SelectEvent.UnSelectPlace)
+            advanceUntilIdle()
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            assertEquals(LoadState.Empty, uiState.value.selectedPlace)
+            assertEquals(MapControlSideEffect.UnselectMarker, event)
+        }
+
+    @Test
+    fun `학교로 돌아가기 버튼이 나타나지 않는 임계값을 넣을 수 있다`() =
+        runTest {
+            // given
+            val isExceededMaxLength = true
+
+            // when
+            selectActionHandler(SelectEvent.ExceededMaxLength(isExceededMaxLength))
+            advanceUntilIdle()
+
+            // then
+            assertEquals(isExceededMaxLength, uiState.value.isExceededMaxLength)
+        }
+
+    @Test
+    fun `현재 플레이스를 선택 후, 플레이스 상세로 이벤트를 발생시킬 수 있다`() =
+        runTest {
+            // given
+            everySuspend {
+                placeDetailRepository.getPlaceDetail(FAKE_PLACE_DETAIL.id)
+            } returns Result.success(FAKE_PLACE_DETAIL)
+
+            val eventResult = observeEvent(placeMapUiEvent.receiveAsFlow())
+            val expected = LoadState.Success(FAKE_PLACE_DETAIL.toUiModel())
+            uiState.update {
+                it.copy(
+                    selectedPlace = expected,
+                    selectedTimeTag = LoadState.Success(FAKE_TIME_TAG),
+                )
+            }
+
+            // when
+            selectActionHandler(
+                SelectEvent.OnPlacePreviewClick(expected),
+            )
+            advanceUntilIdle()
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            assertEquals(PlaceMapSideEffect.StartPlaceDetail(expected), event)
+        }
+
+    @Test
+    fun `타임태그가 선택되었음을 알리는 이벤트를 발생시킬 수 있다`() =
+        runTest {
+            // given
+            val expected = TimeTag(1, "테스트1")
+
+            // when
+            selectActionHandler(SelectEvent.OnTimeTagClick(expected))
+            advanceUntilIdle()
+
+            // then
+            assertEquals(LoadState.Success(expected), uiState.value.selectedTimeTag)
+        }
+
+    @Test
+    fun `뒤로가기가 클릭되었을 때 선택 해제 이벤트를 발생시킬 수 있다`() =
+        runTest {
+            // given
+            val eventResult = observeEvent(mapControlUiEvent.receiveAsFlow())
+
+            // when
+            selectActionHandler(SelectEvent.OnBackPress)
+
+            // then
+            val event = eventResult.await()
+            advanceUntilIdle()
+
+            assertEquals(MapControlSideEffect.UnselectMarker, event)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/SelectActionHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/handler/SelectActionHandlerTest.kt
@@ -171,7 +171,7 @@ class SelectActionHandlerTest {
         }
 
     @Test
-    fun `현재 플레이스를 선택 후, 플레이스 상세로 이벤트를 발생시킬 수 있다`() =
+    fun `현재 플레이스를 선택 후에 플레이스 상세로 이벤트를 발생시킬 수 있다`() =
         runTest {
             // given
             everySuspend {

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleTestFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleTestFixtures.kt
@@ -1,0 +1,52 @@
+package com.daedan.festabook.schedule
+
+import com.daedan.festabook.domain.model.ScheduleDate
+import com.daedan.festabook.domain.model.ScheduleEvent
+import com.daedan.festabook.domain.model.ScheduleEventStatus
+import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiModel
+import com.daedan.festabook.presentation.schedule.model.ScheduleEventUiStatus
+import kotlinx.datetime.LocalDate
+
+val FAKE_SCHEDULE_EVENTS =
+    listOf(
+        ScheduleEvent(
+            id = 1L,
+            status = ScheduleEventStatus.ONGOING,
+            startTime = "10:00",
+            endTime = "11:00",
+            title = "안드로이드 스터디",
+            location = "서울 강남구 어딘가",
+        ),
+        ScheduleEvent(
+            id = 1L,
+            status = ScheduleEventStatus.UPCOMING, // 필요 시 enum 정의에 맞게 변경
+            startTime = "10:00",
+            endTime = "11:00",
+            title = "안드로이드 스터디",
+            location = "서울 강남구 어딘가",
+        ),
+    )
+val FAKE_SCHEDULE_EVENTS_UI_MODELS =
+    listOf(
+        ScheduleEventUiModel(
+            id = 1L,
+            status = ScheduleEventUiStatus.ONGOING, // enum이나 클래스에 맞게 수정
+            startTime = "10:00",
+            endTime = "11:00",
+            title = "안드로이드 스터디",
+            location = "서울 강남구 어딘가",
+        ),
+        ScheduleEventUiModel(
+            id = 1L,
+            status = ScheduleEventUiStatus.UPCOMING, // enum이나 클래스에 맞게 수정
+            startTime = "10:00",
+            endTime = "11:00",
+            title = "안드로이드 스터디",
+            location = "서울 강남구 어딘가",
+        ),
+    )
+
+val FAKE_SCHEDULE_DATES =
+    listOf(
+        ScheduleDate(id = 1L, date = LocalDate(2025, 7, 26)),
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleViewModelTest.kt
@@ -1,0 +1,132 @@
+package com.daedan.festabook.schedule
+
+import com.daedan.festabook.domain.repository.ScheduleRepository
+import com.daedan.festabook.presentation.schedule.ScheduleEventsUiState
+import com.daedan.festabook.presentation.schedule.ScheduleUiState
+import com.daedan.festabook.presentation.schedule.ScheduleViewModel
+import com.daedan.festabook.presentation.schedule.model.toUiModel
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScheduleViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val dateId = 1L
+    private lateinit var scheduleRepository: ScheduleRepository
+    private lateinit var scheduleViewModel: ScheduleViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        scheduleRepository = mock()
+
+        everySuspend { scheduleRepository.fetchAllScheduleDates() } returns
+            Result.success(FAKE_SCHEDULE_DATES)
+        everySuspend { scheduleRepository.fetchScheduleEventsById(dateId) } returns
+            Result.success(FAKE_SCHEDULE_EVENTS)
+
+        scheduleViewModel = ScheduleViewModel(scheduleRepository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `ViewModel이 생성되면 해당 날짜를 불러온다`() =
+        runTest {
+            // given
+            advanceUntilIdle()
+
+            // then
+            val stateResult = scheduleViewModel.scheduleUiState.value.content
+            val expectedDate = FAKE_SCHEDULE_DATES.map { it.toUiModel() }
+
+            verifySuspend { scheduleRepository.fetchAllScheduleDates() }
+            verifySuspend { scheduleRepository.fetchScheduleEventsById(dateId) }
+            assertTrue(stateResult is ScheduleUiState.Content.Success)
+            assertEquals(expectedDate, (stateResult as ScheduleUiState.Content.Success).dates)
+        }
+
+    @Test
+    fun `ViewModel이 생성되면 날짜에 해당하는 일정들을 불러온다`() =
+        runTest {
+            // given
+            advanceUntilIdle()
+
+            // when
+            val state = scheduleViewModel.scheduleUiState.value.content
+
+            // then
+            val successState =
+                state as? ScheduleUiState.Content.Success
+                    ?: fail("ScheduleUiState.Success 가 아님: $state")
+
+            val eventsState =
+                successState.eventsUiStateByPosition[0]?.content as? ScheduleEventsUiState.Content.Success
+                    ?: fail("ScheduleEventsUiState.Success 가 아님")
+
+            verifySuspend { scheduleRepository.fetchAllScheduleDates() }
+            verifySuspend { scheduleRepository.fetchScheduleEventsById(dateId) }
+            assertEquals(FAKE_SCHEDULE_EVENTS_UI_MODELS, eventsState.events)
+        }
+
+    @Test
+    fun `현재 진행중인 날짜의 인덱스를 불러올 수 있다`() =
+        runTest {
+            // given
+            advanceUntilIdle()
+
+            // when
+            val state = scheduleViewModel.scheduleUiState.value.content
+
+            // then
+            val successState =
+                state as? ScheduleUiState.Content.Success
+                    ?: fail("ScheduleUiState.Success 가 아님: $state")
+
+            verifySuspend { scheduleRepository.fetchAllScheduleDates() }
+            verifySuspend { scheduleRepository.fetchScheduleEventsById(dateId) }
+            assertEquals(0, successState.currentDatePosition)
+        }
+
+    @Test
+    fun `현재 진행중인 일정의 인덱스를 불러올 수 있다`() =
+        runTest {
+            // given
+            advanceUntilIdle()
+
+            // when
+            val state = scheduleViewModel.scheduleUiState.value.content
+
+            // then
+            val successState =
+                state as? ScheduleUiState.Content.Success
+                    ?: fail("ScheduleUiState.Success 가 아님: $state")
+            val eventsState =
+                successState.eventsUiStateByPosition[0]?.content as? ScheduleEventsUiState.Content.Success
+                    ?: fail("ScheduleEventsUiState.Success 가 아님")
+
+            verifySuspend { scheduleRepository.fetchAllScheduleDates() }
+            verifySuspend { scheduleRepository.fetchScheduleEventsById(dateId) }
+            assertEquals(0, eventsState.currentEventPosition)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/schedule/ScheduleViewModelTest.kt
@@ -63,7 +63,7 @@ class ScheduleViewModelTest {
             verifySuspend { scheduleRepository.fetchAllScheduleDates() }
             verifySuspend { scheduleRepository.fetchScheduleEventsById(dateId) }
             assertTrue(stateResult is ScheduleUiState.Content.Success)
-            assertEquals(expectedDate, (stateResult as ScheduleUiState.Content.Success).dates)
+            assertEquals(expectedDate, stateResult.dates)
         }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/setting/FestivalNotificationRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/setting/FestivalNotificationRepositoryTest.kt
@@ -1,0 +1,199 @@
+package com.daedan.festabook.setting
+
+import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
+import com.daedan.festabook.data.datasource.local.FestivalNotificationLocalDataSource
+import com.daedan.festabook.data.datasource.remote.ApiResult
+import com.daedan.festabook.data.datasource.remote.festival.FestivalNotificationRemoteDataSource
+import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
+import com.daedan.festabook.data.model.response.festival.RegisteredFestivalNotificationResponse
+import com.daedan.festabook.data.repository.FestivalNotificationRepositoryImpl
+import com.daedan.festabook.domain.repository.FestivalNotificationRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FestivalNotificationRepositoryTest {
+    private lateinit var festivalNotificationRepository: FestivalNotificationRepository
+    private val festivalNotificationDataSource: FestivalNotificationRemoteDataSource =
+        mock(MockMode.autofill)
+    private val deviceLocalDataSource: DeviceLocalDataSource =
+        mock(MockMode.autofill)
+    private val festivalNotificationLocalDataSource: FestivalNotificationLocalDataSource =
+        mock(MockMode.autofill)
+    private val festivalLocalDataSource: FestivalLocalDataSource =
+        mock(MockMode.autofill)
+
+    @BeforeTest
+    fun setup() {
+        everySuspend {
+            deviceLocalDataSource.getDeviceId()
+        } returns flowOf(1)
+        everySuspend {
+            festivalLocalDataSource.getFestivalId()
+        } returns flowOf(1)
+
+        festivalNotificationRepository =
+            FestivalNotificationRepositoryImpl(
+                festivalNotificationDataSource,
+                deviceLocalDataSource,
+                festivalNotificationLocalDataSource,
+                festivalLocalDataSource,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `Notification ID를 저장할 수 있다 `() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationDataSource.saveFestivalNotification(any(), any())
+            } returns
+                ApiResult.Success(
+                    FestivalNotificationResponse(10),
+                )
+
+            // when
+            festivalNotificationRepository.saveFestivalNotification()
+
+            // then
+            verifySuspend(VerifyMode.exactly(1)) {
+                festivalNotificationDataSource.saveFestivalNotification(1, 1)
+                festivalNotificationLocalDataSource.saveFestivalNotificationId(1, 10)
+            }
+        }
+
+    @Test
+    fun `Notification ID를 삭제할 수 있다`() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationLocalDataSource.getFestivalNotificationId(1)
+            } returns flowOf(10)
+            everySuspend {
+                festivalNotificationDataSource.deleteFestivalNotification(10)
+            } returns ApiResult.Success(Unit)
+
+            // when
+            festivalNotificationRepository.deleteFestivalNotification()
+
+            // then
+            verifySuspend(VerifyMode.exactly(1)) {
+                festivalNotificationDataSource.deleteFestivalNotification(10)
+                festivalNotificationLocalDataSource.deleteFestivalNotificationId(1)
+            }
+        }
+
+    @Test
+    fun `서버에서 Notification ID 삭제에 실패하면 로컬에 ID를 삭제하지 않는다`() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationLocalDataSource.getFestivalNotificationId(1)
+            } returns flowOf(10)
+            everySuspend {
+                festivalNotificationDataSource.deleteFestivalNotification(10)
+            } returns ApiResult.ServerError(500, "", "")
+
+            // when
+            festivalNotificationRepository.deleteFestivalNotification()
+
+            // then
+            verifySuspend(VerifyMode.exactly(0)) {
+                festivalNotificationLocalDataSource.deleteFestivalNotificationId(1)
+            }
+        }
+
+    @Test
+    fun `서버에서 Notification ID 저장에 실패하면 로컬에 ID를 저장하지 않는다`() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationDataSource.saveFestivalNotification(any(), any())
+            } returns
+                ApiResult.ServerError(500, "", "")
+
+            // when
+            festivalNotificationRepository.saveFestivalNotification()
+
+            // then
+            verifySuspend(VerifyMode.exactly(0)) {
+                festivalNotificationLocalDataSource.saveFestivalNotificationId(1, 10)
+            }
+        }
+
+    @Test
+    fun `서버에 알람이 등록되어있지 않다면 로컬에 Notification 정보를 삭제할 수 있다`() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationLocalDataSource.getFestivalNotificationId(1)
+            } returns flowOf(1)
+
+            everySuspend {
+                festivalNotificationDataSource.getFestivalNotification(1)
+            } returns ApiResult.Success(listOf())
+
+            // when
+            val result = festivalNotificationRepository.syncFestivalNotificationIsAllow()
+
+            // then
+            assertEquals(false, result.getOrNull())
+            verifySuspend(VerifyMode.exactly(1)) {
+                festivalNotificationLocalDataSource.saveFestivalNotificationIsAllowed(1, false)
+                festivalNotificationLocalDataSource.deleteFestivalNotificationId(1)
+            }
+        }
+
+    @Test
+    fun `서버에 알람이 등록되어 있다면 로컬에 Notification 정보를 저장할 수 있다`() =
+        runTest {
+            // given
+            everySuspend {
+                festivalNotificationLocalDataSource.getFestivalNotificationId(1)
+            } returns flowOf(-1)
+
+            everySuspend {
+                festivalNotificationDataSource.getFestivalNotification(1)
+            } returns
+                ApiResult.Success(
+                    listOf(
+                        RegisteredFestivalNotificationResponse(
+                            festivalNotificationId = 10,
+                            festivalId = 1,
+                            organizationName = "test",
+                            festivalName = "test",
+                        ),
+                    ),
+                )
+
+            // when
+            val result = festivalNotificationRepository.syncFestivalNotificationIsAllow()
+
+            // then
+            assertEquals(true, result.getOrNull())
+            verifySuspend(VerifyMode.exactly(1)) {
+                festivalNotificationLocalDataSource.saveFestivalNotificationIsAllowed(1, true)
+                festivalNotificationLocalDataSource.saveFestivalNotificationId(1, 10)
+            }
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/setting/SettingViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/setting/SettingViewModelTest.kt
@@ -1,0 +1,135 @@
+package com.daedan.festabook.setting
+
+import com.daedan.festabook.domain.repository.FestivalNotificationRepository
+import com.daedan.festabook.observeEvent
+import com.daedan.festabook.presentation.setting.SettingViewModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var settingViewModel: SettingViewModel
+
+    private lateinit var festivalNotificationRepository: FestivalNotificationRepository
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        festivalNotificationRepository = mock(MockMode.autofill)
+        everySuspend { festivalNotificationRepository.syncFestivalNotificationIsAllow() } returns
+            Result.success(false)
+        settingViewModel = SettingViewModel(festivalNotificationRepository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `알림 허용을 클릭했을 때 알림이 허용이 안되있다면 권한 요청 이벤트를 발생시킨다`() =
+        runTest {
+            // given
+            everySuspend { festivalNotificationRepository.getFestivalNotificationIsAllow() } returns flowOf(false)
+            everySuspend { festivalNotificationRepository.syncFestivalNotificationIsAllow() } returns
+                Result.success(false)
+
+            settingViewModel = SettingViewModel(festivalNotificationRepository)
+            val event = observeEvent(settingViewModel.permissionCheckEvent)
+
+            // when
+            settingViewModel.notificationAllowClick()
+            advanceUntilIdle()
+
+            // then
+            val actual = event.await()
+            advanceUntilIdle()
+            assertEquals(Unit, actual)
+        }
+
+    @Test
+    fun `알림 허용을 클릭했을 때 알림이 허용이 되있다면 알림id를 삭제한다`() =
+        runTest {
+            // given
+            everySuspend { festivalNotificationRepository.getFestivalNotificationIsAllow() } returns flowOf(true)
+            everySuspend { festivalNotificationRepository.syncFestivalNotificationIsAllow() } returns
+                Result.success(true)
+            everySuspend { festivalNotificationRepository.deleteFestivalNotification() } returns
+                Result.success(Unit)
+
+            // when
+            settingViewModel = SettingViewModel(festivalNotificationRepository)
+            advanceUntilIdle()
+
+            settingViewModel.notificationAllowClick()
+            advanceUntilIdle()
+
+            // then
+            val result = settingViewModel.isAllowed.value
+            verifySuspend { festivalNotificationRepository.saveFestivalNotificationIsAllow(false) }
+            verifySuspend { festivalNotificationRepository.deleteFestivalNotification() }
+            assertFalse(result)
+        }
+
+    @Test
+    fun `알림 허용을 클릭했을 때 서버에 알림 정보 저장에 실패하면 이전 상태로 원복한다`() =
+        runTest {
+            // given
+            everySuspend { festivalNotificationRepository.getFestivalNotificationIsAllow() } returns flowOf(true)
+            everySuspend { festivalNotificationRepository.syncFestivalNotificationIsAllow() } returns
+                Result.success(true)
+            everySuspend { festivalNotificationRepository.deleteFestivalNotification() } returns
+                Result.failure(
+                    Throwable(),
+                )
+
+            // when
+            settingViewModel = SettingViewModel(festivalNotificationRepository)
+            advanceUntilIdle()
+            settingViewModel.notificationAllowClick()
+            advanceUntilIdle()
+
+            // then
+            val result = settingViewModel.isAllowed.value
+            verifySuspend { festivalNotificationRepository.saveFestivalNotificationIsAllow(true) }
+            assertTrue(result)
+        }
+
+    @Test
+    fun `알림을 허용했을 때 서버에 알림 정보 삭제에 실패하면 이전 상태로 원복한다`() =
+        runTest {
+            // given
+            everySuspend { festivalNotificationRepository.saveFestivalNotification() } returns
+                Result.failure(
+                    Throwable(),
+                )
+
+            // when
+            settingViewModel.saveNotificationId()
+            advanceUntilIdle()
+
+            // then
+            val result = settingViewModel.isAllowed.value
+            verifySuspend { festivalNotificationRepository.saveFestivalNotificationIsAllow(false) }
+            assertFalse(result)
+        }
+}

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/splash/SplashViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/splash/SplashViewModelTest.kt
@@ -1,0 +1,96 @@
+package com.daedan.festabook.splash
+
+import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
+import com.daedan.festabook.presentation.splash.SplashUiState
+import com.daedan.festabook.presentation.splash.SplashViewModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SplashViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var festivalLocalDataSource: FestivalLocalDataSource
+    private lateinit var splashViewModel: SplashViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        festivalLocalDataSource = mock(MockMode.autofill)
+        splashViewModel = SplashViewModel(festivalLocalDataSource, iODispatcher = testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `앱 업데이트가 있다면 업데이트 다이얼로그를 표시한다`() =
+        runTest {
+            // given
+            val updateResult = Result.success(true)
+
+            // when
+            splashViewModel.handleVersionCheckResult(updateResult)
+
+            // then
+            assertEquals(SplashUiState.ShowUpdateDialog, splashViewModel.uiState.value)
+        }
+
+    @Test
+    fun `앱 업데이트 확인에 실패하면 네트워크 에러 다이얼로그를 표시한다`() =
+        runTest {
+            // given
+            val updateResult = Result.failure<Boolean>(Exception("Network Error"))
+
+            // when
+            splashViewModel.handleVersionCheckResult(updateResult)
+
+            // then
+            assertEquals(SplashUiState.ShowNetworkErrorDialog, splashViewModel.uiState.value)
+        }
+
+    @Test
+    fun `앱 업데이트가 없고 접속한 대학교가 있다면 MainActivity로 이동한다`() =
+        runTest {
+            every { festivalLocalDataSource.getFestivalId() } returns flowOf(1L)
+            val updateResult = Result.success(false)
+
+            // when
+            splashViewModel.handleVersionCheckResult(updateResult)
+
+            // then
+            assertEquals(SplashUiState.NavigateToMain(1L), splashViewModel.uiState.value)
+            verify(VerifyMode.exactly(1)) { festivalLocalDataSource.getFestivalId() }
+        }
+
+    @Test
+    fun `앱 업데이트가 없고 접속한 대학교가 없다면 ExploreActivity로 이동한다`() =
+        runTest {
+            // given
+            every { festivalLocalDataSource.getFestivalId() } returns flowOf(null)
+            val updateResult = Result.success(false)
+
+            // when
+            splashViewModel.handleVersionCheckResult(updateResult)
+
+            // then
+            assertEquals(SplashUiState.NavigateToExplore, splashViewModel.uiState.value)
+            verify(VerifyMode.exactly(1)) { festivalLocalDataSource.getFestivalId() }
+        }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #86 

<br>

## 🛠️ 작업 내용

- ViewModelTest를 마이그레이션 하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 축제 알림 권한 상태를 서버와 자동으로 동기화하는 기능을 추가했습니다.

* **개선**
  * 지도 필터링 및 장소 선택 이벤트 처리 로직을 개선했습니다.

* **테스트**
  * 뷰모델, 저장소, 이벤트 핸들러에 대한 광범위한 단위 테스트를 추가하여 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->