### PR TITLE
[Fix] 축제 라인업 불러오지 못하는 버그 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/lineup/LineupResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/response/lineup/LineupResponse.kt
@@ -1,12 +1,10 @@
 package com.daedan.festabook.data.model.response.lineup
 
 import com.daedan.festabook.domain.model.LineupItem
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 @Serializable
 data class LineupResponse(
@@ -26,5 +24,5 @@ fun LineupResponse.toDomain(): LineupItem =
         id = lineupId,
         imageUrl = imageUrl,
         name = name,
-        performanceAt = Instant.parse(performanceAt).toLocalDateTime(TimeZone.UTC),
+        performanceAt = LocalDateTime.parse(performanceAt),
     )


### PR DESCRIPTION
* **refactor: LineupResponse 내 날짜 변환 로직 간소화**
    * `LineupResponse.kt`: `performanceAt` 문자열을 `Instant`를 거쳐 UTC 기준의 `LocalDateTime`으로 변환하던 방식을 `LocalDateTime.parse()`를 직접 사용하도록 수정했습니다.

## #️⃣ 이슈 번호

> #99 

<br>

## 🛠️ 작업 내용

- 축제 라인업을 불러오지 못하는 버그를 해결했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 절대 시간을 파싱하는 Instant대신 LocalDateTime.parse를 사용하였습니다. 
<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

이 업데이트는 내부 기술 개선 사항으로, 사용자에게 직접 영향을 미치는 새로운 기능이나 버그 수정은 없습니다.

* **Refactor**
  * 공연 시간 데이터 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->