### PR TITLE
[Feat] 탐색 화면 최근 검색어 저장 기능 추가

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -281,28 +281,48 @@ val updateIosVersion by tasks.registering {
     val versionName = providers.gradleProperty("APP_VERSION_NAME")
     val versionCode = providers.gradleProperty("APP_VERSION_CODE")
 
-    inputs.file(plistFile)
-    inputs.property("versionName", versionName)
-    inputs.property("versionCode", versionCode)
-
     doLast {
         val file = plistFile.asFile
-
         var text = file.readText()
 
-        text = text.replace(
-            Regex("<key>CFBundleShortVersionString</key>\\s*<string>.*</string>"),
-            "<key>CFBundleShortVersionString</key>\n\t\t<string>${versionName.get()}</string>"
-        )
+        // CFBundleShortVersionString
+        text = if (text.contains("<key>CFBundleShortVersionString</key>")) {
+            text.replace(
+                Regex("<key>CFBundleShortVersionString</key>\\s*<string>.*</string>"),
+                "<key>CFBundleShortVersionString</key>\n\t\t<string>${versionName.get()}</string>"
+            )
+        } else {
+            text.replace(
+                "</dict>",
+                """
+                    <key>CFBundleShortVersionString</key>
+                    <string>${versionName.get()}</string>
+                    </dict>
+                    """.trimIndent()
+            )
+        }
 
-        text = text.replace(
-            Regex("<key>CFBundleVersion</key>\\s*<string>.*</string>"),
-            "<key>CFBundleVersion</key>\n\t\t<string>${versionCode.get()}</string>"
-        )
+        // CFBundleVersion
+        text = if (text.contains("<key>CFBundleVersion</key>")) {
+            text.replace(
+                Regex("<key>CFBundleVersion</key>\\s*<string>.*</string>"),
+                "<key>CFBundleVersion</key>\n\t\t<string>${versionCode.get()}</string>"
+            )
+        } else {
+            text.replace(
+                "</dict>",
+                """
+                    <key>CFBundleVersion</key>
+                    <string>${versionCode.get()}</string>
+                    </dict>
+                    """.trimIndent()
+            )
+        }
 
         file.writeText(text)
     }
 }
+
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile>().configureEach {
     dependsOn(updateIosVersion)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="explore_error_text">오류가 발생했습니다: %1$s</string>
     <string name="recent_searches">최근 검색어</string>
     <string name="clear_all">전체삭제</string>
+    <string name="no_recent_searches_message">최근 검색어 내역이 없습니다.</string>
+    <string name="content_description_close">닫기 버튼</string>
 
     <!--일정 화면-->
     <string name="schedule_title">일정 타임라인</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="explore_festabook_logo">festabook_logo</string>
     <string name="explore_no_search_result_text">철자가 맞는지 확인해주세요</string>
     <string name="explore_error_text">오류가 발생했습니다: %1$s</string>
+    <string name="recent_searches">최근 검색어</string>
+    <string name="clear_all">전체삭제</string>
 
     <!--일정 화면-->
     <string name="schedule_title">일정 타임라인</string>

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -1,11 +1,16 @@
 package com.daedan.festabook.data.datasource.local
 
+import com.daedan.festabook.data.model.entity.FestivalSearchItemEntity
 import kotlinx.coroutines.flow.Flow
 
 interface FestivalLocalDataSource {
     suspend fun saveFestivalId(festivalId: Long)
 
     fun getFestivalId(): Flow<Long?>
+
+    suspend fun saveRecentFestivalSearch(festivalSearchItemEntity: FestivalSearchItemEntity)
+
+    fun getRecentFestivalSearches(): Flow<List<FestivalSearchItemEntity>>
 
     fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -14,5 +14,7 @@ interface FestivalLocalDataSource {
 
     suspend fun clearRecentFestivalSearches()
 
+    suspend fun deleteRecentFestivalSearch(festivalSearchItemEntity: FestivalSearchItemEntity)
+
     fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSource.kt
@@ -12,5 +12,7 @@ interface FestivalLocalDataSource {
 
     fun getRecentFestivalSearches(): Flow<List<FestivalSearchItemEntity>>
 
+    suspend fun clearRecentFestivalSearches()
+
     fun getIsFirstVisit(): Flow<Boolean>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -72,6 +72,23 @@ class FestivalLocalDataSourceImpl(
         }
     }
 
+    override suspend fun deleteRecentFestivalSearch(festivalSearchItemEntity: FestivalSearchItemEntity) {
+        dataStore.edit { preferences ->
+            val currentJson = preferences[FESTIVAL_SEARCH_ITEM] ?: ""
+
+            val festivalSearchItemEntities =
+                if (currentJson.isNotEmpty()) {
+                    Json.decodeFromString<MutableList<FestivalSearchItemEntity>>(currentJson)
+                } else {
+                    mutableListOf()
+                }
+
+            festivalSearchItemEntities.remove(festivalSearchItemEntity)
+
+            preferences[FESTIVAL_SEARCH_ITEM] = Json.encodeToString(festivalSearchItemEntities)
+        }
+    }
+
     override fun getIsFirstVisit(): Flow<Boolean> =
         getFestivalId().map { festivalId ->
             val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -77,10 +77,10 @@ class FestivalLocalDataSourceImpl(
             val currentJson = preferences[FESTIVAL_SEARCH_ITEM] ?: ""
 
             val festivalSearchItemEntities =
-                if (currentJson.isNotEmpty()) {
-                    Json.decodeFromString<MutableList<FestivalSearchItemEntity>>(currentJson)
-                } else {
+                if (currentJson.isEmpty()) {
                     mutableListOf()
+                } else {
+                    Json.decodeFromString<MutableList<FestivalSearchItemEntity>>(currentJson)
                 }
 
             festivalSearchItemEntities.remove(festivalSearchItemEntity)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -47,10 +47,9 @@ class FestivalLocalDataSourceImpl(
             val updatedList =
                 (
                     listOf(festivalSearchItemEntity) +
-                        currentList
-                            .filter { it.festivalId != festivalSearchItemEntity.festivalId }
-                            .take(MAX_RECENT_SEARCH_COUNT)
-                )
+                        currentList.filter { it.festivalId != festivalSearchItemEntity.festivalId }
+
+                ).take(MAX_RECENT_SEARCH_COUNT)
 
             preferences[FESTIVAL_SEARCH_ITEM] = Json.encodeToString(updatedList)
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -39,11 +39,8 @@ class FestivalLocalDataSourceImpl(
             val currentJson = preferences[FESTIVAL_SEARCH_ITEM] ?: ""
 
             val currentList =
-                if (currentJson.isEmpty()) {
-                    emptyList<FestivalSearchItemEntity>()
-                } else {
-                    Json.decodeFromString(currentJson)
-                }
+                decodeFromStringOrDefault<List<FestivalSearchItemEntity>>(currentJson, emptyList())
+
             val updatedList =
                 (
                     listOf(festivalSearchItemEntity) +
@@ -76,11 +73,10 @@ class FestivalLocalDataSourceImpl(
             val currentJson = preferences[FESTIVAL_SEARCH_ITEM] ?: ""
 
             val festivalSearchItemEntities =
-                if (currentJson.isEmpty()) {
-                    mutableListOf()
-                } else {
-                    Json.decodeFromString<MutableList<FestivalSearchItemEntity>>(currentJson)
-                }
+                decodeFromStringOrDefault<MutableList<FestivalSearchItemEntity>>(
+                    currentJson,
+                    mutableListOf(),
+                )
 
             festivalSearchItemEntities.remove(festivalSearchItemEntity)
 
@@ -105,5 +101,17 @@ class FestivalLocalDataSourceImpl(
         private const val MAX_RECENT_SEARCH_COUNT = 5
         private val FESTIVAL_SEARCH_ITEM = stringPreferencesKey("festival_search_item")
         private val KEY_FESTIVAL_ID = longPreferencesKey("festival_id")
+
+        private inline fun <reified T> decodeFromStringOrDefault(
+            json: String,
+            default: T,
+        ): T =
+            runCatching {
+                Json.decodeFromString<T>(json)
+            }.onFailure {
+                // TODO 실패 로그 필요
+            }.getOrElse {
+                default
+            }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -7,12 +7,15 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.daedan.festabook.data.model.entity.FestivalSearchItemEntity
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -31,6 +34,37 @@ class FestivalLocalDataSourceImpl(
                 if (it is IOException) emit(emptyPreferences()) else throw it
             }.map { it[KEY_FESTIVAL_ID] }
 
+    override suspend fun saveRecentFestivalSearch(festivalSearchItemEntity: FestivalSearchItemEntity) {
+        dataStore.edit { preferences ->
+            val currentJson = preferences[FESTIVAL_SEARCH_ITEM] ?: ""
+
+            val currentList =
+                if (currentJson.isEmpty()) {
+                    emptyList<FestivalSearchItemEntity>()
+                } else {
+                    Json.decodeFromString(currentJson)
+                }
+            val updatedList =
+                (
+                    listOf(festivalSearchItemEntity) +
+                        currentList
+                            .filter { it.festivalId != festivalSearchItemEntity.festivalId }
+                            .take(MAX_RECENT_SEARCH_COUNT)
+                )
+
+            preferences[FESTIVAL_SEARCH_ITEM] = Json.encodeToString(updatedList)
+        }
+    }
+
+    override fun getRecentFestivalSearches(): Flow<List<FestivalSearchItemEntity>> =
+        dataStore.data
+            .catch {
+                if (it is IOException) emit(emptyPreferences()) else throw it
+            }.map {
+                val json = it[FESTIVAL_SEARCH_ITEM] ?: ""
+                if (json.isEmpty()) emptyList() else Json.decodeFromString(json)
+            }
+
     override fun getIsFirstVisit(): Flow<Boolean> =
         getFestivalId().map { festivalId ->
             val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")
@@ -45,6 +79,8 @@ class FestivalLocalDataSourceImpl(
 
     companion object {
         private const val KEY_IS_FIRST_VISIT = "is_first_visit"
+        private const val MAX_RECENT_SEARCH_COUNT = 10
+        private val FESTIVAL_SEARCH_ITEM = stringPreferencesKey("festival_search_item")
         private val KEY_FESTIVAL_ID = longPreferencesKey("festival_id")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/local/FestivalLocalDataSourceImpl.kt
@@ -65,6 +65,13 @@ class FestivalLocalDataSourceImpl(
                 if (json.isEmpty()) emptyList() else Json.decodeFromString(json)
             }
 
+    override suspend fun clearRecentFestivalSearches() {
+        dataStore.edit { preferences ->
+            preferences[FESTIVAL_SEARCH_ITEM] =
+                Json.encodeToString(emptyList<FestivalSearchItemEntity>())
+        }
+    }
+
     override fun getIsFirstVisit(): Flow<Boolean> =
         getFestivalId().map { festivalId ->
             val key = booleanPreferencesKey("${KEY_IS_FIRST_VISIT}_$festivalId")
@@ -79,7 +86,7 @@ class FestivalLocalDataSourceImpl(
 
     companion object {
         private const val KEY_IS_FIRST_VISIT = "is_first_visit"
-        private const val MAX_RECENT_SEARCH_COUNT = 10
+        private const val MAX_RECENT_SEARCH_COUNT = 5
         private val FESTIVAL_SEARCH_ITEM = stringPreferencesKey("festival_search_item")
         private val KEY_FESTIVAL_ID = longPreferencesKey("festival_id")
     }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/entity/FestivalSearchItemEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/model/entity/FestivalSearchItemEntity.kt
@@ -1,0 +1,31 @@
+package com.daedan.festabook.data.model.entity
+
+import com.daedan.festabook.domain.model.FestivalSearchItem
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FestivalSearchItemEntity(
+    val festivalId: Long,
+    val organizationName: String,
+    val festivalName: String,
+    val startDate: String,
+    val endDate: String,
+)
+
+fun FestivalSearchItemEntity.toDomain() =
+    FestivalSearchItem(
+        festivalId = festivalId,
+        organizationName = organizationName,
+        festivalName = festivalName,
+        startDate = startDate,
+        endDate = endDate,
+    )
+
+fun FestivalSearchItem.toEntity() =
+    FestivalSearchItemEntity(
+        festivalId = festivalId,
+        organizationName = organizationName,
+        festivalName = festivalName,
+        startDate = startDate,
+        endDate = endDate,
+    )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.daedan.festabook.data.repository
 
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
 import com.daedan.festabook.data.datasource.remote.festival.FestivalRemoteDataSource
+import com.daedan.festabook.data.model.entity.toDomain
+import com.daedan.festabook.data.model.entity.toEntity
 import com.daedan.festabook.data.model.response.toDomain
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.data.util.withTimeoutOrNullFallback
@@ -10,7 +12,9 @@ import com.daedan.festabook.domain.repository.ExploreRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 
 @ContributesBinding(AppScope::class)
 @Inject
@@ -36,4 +40,12 @@ class ExploreRepositoryImpl(
             producer = { festivalLocalDataSource.getFestivalId().firstOrNull() },
             onFallback = { /*TODO 로그 */ },
         )
+
+    override suspend fun saveRecentFestivalSearch(festivalSearchItem: FestivalSearchItem) =
+        festivalLocalDataSource.saveRecentFestivalSearch(festivalSearchItem.toEntity())
+
+    override fun getRecentFestivalSearches(): Flow<List<FestivalSearchItem>> =
+        festivalLocalDataSource.getRecentFestivalSearches().map { entites ->
+            entites.map { it.toDomain() }
+        }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -45,11 +45,12 @@ class ExploreRepositoryImpl(
         festivalLocalDataSource.saveRecentFestivalSearch(festivalSearchItem.toEntity())
 
     override fun getRecentFestivalSearches(): Flow<List<FestivalSearchItem>> =
-        festivalLocalDataSource.getRecentFestivalSearches().map { entites ->
-            entites.map { it.toDomain() }
+        festivalLocalDataSource.getRecentFestivalSearches().map { entities ->
+            entities.map { it.toDomain() }
         }
 
-    override suspend fun clearRecentFestivalSearches() {
-        festivalLocalDataSource.clearRecentFestivalSearches()
-    }
+    override suspend fun clearRecentFestivalSearches() = festivalLocalDataSource.clearRecentFestivalSearches()
+
+    override suspend fun deleteRecentFestivalSearch(festivalSearchItem: FestivalSearchItem) =
+        festivalLocalDataSource.deleteRecentFestivalSearch(festivalSearchItem.toEntity())
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/ExploreRepositoryImpl.kt
@@ -48,4 +48,8 @@ class ExploreRepositoryImpl(
         festivalLocalDataSource.getRecentFestivalSearches().map { entites ->
             entites.map { it.toDomain() }
         }
+
+    override suspend fun clearRecentFestivalSearches() {
+        festivalLocalDataSource.clearRecentFestivalSearches()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.domain.repository
 
 import com.daedan.festabook.domain.model.FestivalSearchItem
+import kotlinx.coroutines.flow.Flow
 
 interface ExploreRepository {
     suspend fun search(query: String): Result<List<FestivalSearchItem>>
@@ -8,4 +9,8 @@ interface ExploreRepository {
     suspend fun saveFestivalId(festivalId: Long)
 
     suspend fun getFestivalId(): Long?
+
+    suspend fun saveRecentFestivalSearch(festivalSearchItem: FestivalSearchItem)
+
+    fun getRecentFestivalSearches(): Flow<List<FestivalSearchItem>>
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
@@ -15,4 +15,6 @@ interface ExploreRepository {
     fun getRecentFestivalSearches(): Flow<List<FestivalSearchItem>>
 
     suspend fun clearRecentFestivalSearches()
+
+    suspend fun deleteRecentFestivalSearch(festivalSearchItem: FestivalSearchItem)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/domain/repository/ExploreRepository.kt
@@ -13,4 +13,6 @@ interface ExploreRepository {
     suspend fun saveRecentFestivalSearch(festivalSearchItem: FestivalSearchItem)
 
     fun getRecentFestivalSearches(): Flow<List<FestivalSearchItem>>
+
+    suspend fun clearRecentFestivalSearches()
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreUiState.kt
@@ -1,7 +1,10 @@
 package com.daedan.festabook.presentation.explore
 
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+
 data class ExploreUiState(
     val query: String = "",
     val searchState: SearchUiState = SearchUiState.Idle,
     val hasFestivalId: Boolean = false,
+    val recentSearches: List<SearchResultUiModel> = emptyList(),
 )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -11,6 +11,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,6 +38,8 @@ class ExploreViewModel(
         MutableSharedFlow<ExploreSideEffect>(replay = 0, extraBufferCapacity = 1)
     val sideEffect = _sideEffect.asSharedFlow()
 
+    private var recentSearchJob: Job? = null
+
     init {
         checkFestivalId()
         observeRecentSearches()
@@ -44,10 +47,11 @@ class ExploreViewModel(
     }
 
     fun onUniversitySelected(university: SearchResultUiModel) {
+        recentSearchJob?.cancel()
         viewModelScope.launch {
             exploreRepository.saveFestivalId(university.festivalId)
-            _sideEffect.emit(ExploreSideEffect.NavigateToMain(university))
             exploreRepository.saveRecentFestivalSearch(university.toDomain())
+            _sideEffect.emit(ExploreSideEffect.NavigateToMain(university))
         }
     }
 
@@ -110,11 +114,12 @@ class ExploreViewModel(
     }
 
     private fun observeRecentSearches() {
-        viewModelScope.launch {
-            exploreRepository.getRecentFestivalSearches().collect { festivalSearchItems ->
-                val recentSearches = festivalSearchItems.map { it.toUiModel() }
-                _uiState.update { it.copy(recentSearches = recentSearches) }
+        recentSearchJob =
+            viewModelScope.launch {
+                exploreRepository.getRecentFestivalSearches().collect { festivalSearchItems ->
+                    val recentSearches = festivalSearchItems.map { it.toUiModel() }
+                    _uiState.update { it.copy(recentSearches = recentSearches) }
+                }
             }
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.daedan.festabook.di.viewmodel.ViewModelKey
 import com.daedan.festabook.domain.repository.ExploreRepository
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+import com.daedan.festabook.presentation.explore.model.toDomain
 import com.daedan.festabook.presentation.explore.model.toUiModel
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,6 +42,24 @@ class ExploreViewModel(
         checkFestivalId()
         observeRecentSearches()
         observeSearchQuery()
+    }
+
+    fun onUniversitySelected(university: SearchResultUiModel) {
+        viewModelScope.launch {
+            exploreRepository.saveFestivalId(university.festivalId)
+            _sideEffect.emit(ExploreSideEffect.NavigateToMain(university))
+            exploreRepository.saveRecentFestivalSearch(university.toDomain())
+        }
+    }
+
+    fun onTextInputChanged(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+
+    fun onClearRecentSearches() {
+        viewModelScope.launch {
+            exploreRepository.clearRecentFestivalSearches()
+        }
     }
 
     private fun checkFestivalId() {
@@ -84,21 +104,11 @@ class ExploreViewModel(
         }
     }
 
-    fun onUniversitySelected(university: SearchResultUiModel) {
-        viewModelScope.launch {
-            exploreRepository.saveFestivalId(university.festivalId)
-            _sideEffect.emit(ExploreSideEffect.NavigateToMain(university))
-        }
-    }
-
-    fun onTextInputChanged(query: String) {
-        _uiState.update { it.copy(query = query) }
-    }
-
     private fun observeRecentSearches() {
         viewModelScope.launch {
             exploreRepository.getRecentFestivalSearches().collect { festivalSearchItems ->
                 val recentSearches = festivalSearchItems.map { it.toUiModel() }
+                Napier.d("recentSearches: $recentSearches")
                 _uiState.update { it.copy(recentSearches = recentSearches) }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -32,11 +32,13 @@ class ExploreViewModel(
     private val _uiState = MutableStateFlow(ExploreUiState())
     val uiState: StateFlow<ExploreUiState> = _uiState.asStateFlow()
 
-    private val _sideEffect = MutableSharedFlow<ExploreSideEffect>(replay = 0, extraBufferCapacity = 1)
+    private val _sideEffect =
+        MutableSharedFlow<ExploreSideEffect>(replay = 0, extraBufferCapacity = 1)
     val sideEffect = _sideEffect.asSharedFlow()
 
     init {
         checkFestivalId()
+        observeRecentSearches()
         observeSearchQuery()
     }
 
@@ -91,5 +93,14 @@ class ExploreViewModel(
 
     fun onTextInputChanged(query: String) {
         _uiState.update { it.copy(query = query) }
+    }
+
+    private fun observeRecentSearches() {
+        viewModelScope.launch {
+            exploreRepository.getRecentFestivalSearches().collect { festivalSearchItems ->
+                val recentSearches = festivalSearchItems.map { it.toUiModel() }
+                _uiState.update { it.copy(recentSearches = recentSearches) }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -62,6 +62,12 @@ class ExploreViewModel(
         }
     }
 
+    fun onRecentSearchDelete(university: SearchResultUiModel) {
+        viewModelScope.launch {
+            // TODO 제거 로직 구현 필요
+        }
+    }
+
     private fun checkFestivalId() {
         viewModelScope.launch {
             val festivalId = exploreRepository.getFestivalId()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -10,7 +10,6 @@ import com.daedan.festabook.presentation.explore.model.toUiModel
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
-import io.github.aakira.napier.Napier
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -114,7 +113,6 @@ class ExploreViewModel(
         viewModelScope.launch {
             exploreRepository.getRecentFestivalSearches().collect { festivalSearchItems ->
                 val recentSearches = festivalSearchItems.map { it.toUiModel() }
-                Napier.d("recentSearches: $recentSearches")
                 _uiState.update { it.copy(recentSearches = recentSearches) }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/ExploreViewModel.kt
@@ -64,7 +64,7 @@ class ExploreViewModel(
 
     fun onRecentSearchDelete(university: SearchResultUiModel) {
         viewModelScope.launch {
-            // TODO 제거 로직 구현 필요
+            exploreRepository.deleteRecentFestivalSearch(university.toDomain())
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/SearchUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/SearchUiState.kt
@@ -13,7 +13,6 @@ sealed interface SearchUiState {
 
     data class Success(
         val universitiesFound: List<SearchResultUiModel> = emptyList(),
-//        val selectedUniversity: University? = null,
     ) : SearchUiState {
         override val isEmptyResult: Boolean
             get() = universitiesFound.isEmpty()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -1,0 +1,50 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.ExploreUiState
+import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
+
+@Composable
+fun ExploreLandingContent(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    keyboardController: SoftwareKeyboardController?,
+    isError: Boolean,
+    isSearchMode: Boolean,
+    exploreUiState: ExploreUiState,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+) {
+    ExploreSearchBar(
+        query = query,
+        onQueryChange = onQueryChange,
+        onSearch = { keyboardController?.hide() },
+        isError = isError,
+        modifier = Modifier.padding(horizontal = 20.dp),
+    )
+
+    AnimatedContent(
+        targetState = isSearchMode,
+        transitionSpec = {
+            ContentTransform(
+                targetContentEnter = fadeIn(tween(200)),
+                initialContentExit = fadeOut(tween(200)),
+            )
+        },
+    ) { searching ->
+        if (searching) {
+            ExploreSearchResultList(
+                exploreUiState = exploreUiState,
+                onUniversitySelect = onUniversitySelect,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,31 +27,32 @@ fun ExploreLandingContent(
     exploreUiState: ExploreUiState,
     modifier: Modifier = Modifier,
 ) {
-    ExploreSearchBar(
-        query = query,
-        onQueryChange = onQueryChange,
-        onSearch = { keyboardController?.hide() },
-        isError = isError,
-        modifier = modifier.padding(horizontal = 20.dp),
-    )
+    Column(modifier = modifier) {
+        ExploreSearchBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            onSearch = { keyboardController?.hide() },
+            isError = isError,
+            modifier = Modifier.padding(horizontal = 20.dp),
+        )
 
-    AnimatedContent(
-        targetState = isSearchMode,
-        transitionSpec = {
-            ContentTransform(
-                targetContentEnter = fadeIn(tween(200)),
-                initialContentExit = fadeOut(tween(200)),
-            )
-        },
-        modifier = modifier,
-    ) { searching ->
-        if (searching) {
-            ExploreSearchResultList(
-                exploreUiState = exploreUiState,
-                onUniversitySelect = onUniversitySelect,
-                onClearRecentSearches = onClearRecentSearches,
-                onUniversityDelete = onUniversityDelete,
-            )
+        AnimatedContent(
+            targetState = isSearchMode,
+            transitionSpec = {
+                ContentTransform(
+                    targetContentEnter = fadeIn(tween(200)),
+                    initialContentExit = fadeOut(tween(200)),
+                )
+            },
+        ) { searching ->
+            if (searching) {
+                ExploreSearchResultList(
+                    exploreUiState = exploreUiState,
+                    onUniversitySelect = onUniversitySelect,
+                    onClearRecentSearches = onClearRecentSearches,
+                    onUniversityDelete = onUniversityDelete,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -24,13 +24,14 @@ fun ExploreLandingContent(
     isError: Boolean,
     isSearchMode: Boolean,
     exploreUiState: ExploreUiState,
+    modifier: Modifier = Modifier,
 ) {
     ExploreSearchBar(
         query = query,
         onQueryChange = onQueryChange,
         onSearch = { keyboardController?.hide() },
         isError = isError,
-        modifier = Modifier.padding(horizontal = 20.dp),
+        modifier = modifier.padding(horizontal = 20.dp),
     )
 
     AnimatedContent(
@@ -41,6 +42,7 @@ fun ExploreLandingContent(
                 initialContentExit = fadeOut(tween(200)),
             )
         },
+        modifier = modifier,
     ) { searching ->
         if (searching) {
             ExploreSearchResultList(

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -22,6 +22,7 @@ fun ExploreLandingContent(
     isSearchMode: Boolean,
     exploreUiState: ExploreUiState,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
     onClearRecentSearches: () -> Unit,
 ) {
     ExploreSearchBar(
@@ -46,6 +47,7 @@ fun ExploreLandingContent(
                 exploreUiState = exploreUiState,
                 onUniversitySelect = onUniversitySelect,
                 onClearRecentSearches = onClearRecentSearches,
+                onUniversityDelete = onUniversityDelete,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -22,6 +22,7 @@ fun ExploreLandingContent(
     isSearchMode: Boolean,
     exploreUiState: ExploreUiState,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
 ) {
     ExploreSearchBar(
         query = query,
@@ -44,6 +45,7 @@ fun ExploreLandingContent(
             ExploreSearchResultList(
                 exploreUiState = exploreUiState,
                 onUniversitySelect = onUniversitySelect,
+                onClearRecentSearches = onClearRecentSearches,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreLandingContent.kt
@@ -17,13 +17,13 @@ import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
 fun ExploreLandingContent(
     query: String,
     onQueryChange: (String) -> Unit,
+    onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
     keyboardController: SoftwareKeyboardController?,
     isError: Boolean,
     isSearchMode: Boolean,
     exploreUiState: ExploreUiState,
-    onUniversitySelect: (SearchResultUiModel) -> Unit,
-    onUniversityDelete: (SearchResultUiModel) -> Unit,
-    onClearRecentSearches: () -> Unit,
 ) {
     ExploreSearchBar(
         query = query,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreResultItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreResultItem.kt
@@ -1,17 +1,26 @@
 package com.daedan.festabook.presentation.explore.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
 import com.daedan.festabook.presentation.theme.FestabookColor
 import com.daedan.festabook.presentation.theme.FestabookTheme
 import com.daedan.festabook.presentation.theme.FestabookTypography
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.content_description_close
+import festabookkmp.composeapp.generated.resources.ic_close
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -19,24 +28,39 @@ fun ExploreResultItem(
     university: SearchResultUiModel,
     onItemClick: (SearchResultUiModel) -> Unit,
     modifier: Modifier = Modifier,
+    onDeleteClick: (SearchResultUiModel) -> Unit = {},
+    canDelete: Boolean = false,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .clickable { onItemClick(university) }
-                .padding(vertical = 8.dp, horizontal = 4.dp),
+    Row(
+        modifier = modifier.fillMaxSize().padding(vertical = 8.dp, horizontal = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = university.universityName,
-            style = FestabookTypography.bodyLarge,
-            color = FestabookColor.gray800,
-        )
-        Text(
-            text = university.festivalName,
-            style = FestabookTypography.bodySmall,
-            color = FestabookColor.gray600,
-        )
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .clickable { onItemClick(university) },
+        ) {
+            Text(
+                text = university.universityName,
+                style = FestabookTypography.bodyLarge,
+                color = FestabookColor.gray800,
+            )
+            Text(
+                text = university.festivalName,
+                style = FestabookTypography.bodySmall,
+                color = FestabookColor.gray600,
+            )
+        }
+        if (canDelete) {
+            Icon(
+                painter = painterResource(Res.drawable.ic_close),
+                contentDescription = stringResource(Res.string.content_description_close),
+                tint = FestabookColor.gray600,
+                modifier = Modifier.clickable { onDeleteClick(university) },
+            )
+        }
     }
 }
 
@@ -47,6 +71,7 @@ private fun ExploreResultItemPreview() {
         ExploreResultItem(
             university = SearchResultUiModel(1, "서울시립대학교", "2024 대동제"),
             onItemClick = {},
+            onDeleteClick = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
@@ -64,6 +64,7 @@ fun ExploreScreen(
             onQueryChange = viewModel::onTextInputChanged,
             onUniversitySelect = viewModel::onUniversitySelected,
             onBackClick = onBackClick,
+            onClearRecentSearches = viewModel::onClearRecentSearches,
         )
     } else {
         ExploreLandingScreen(
@@ -71,6 +72,7 @@ fun ExploreScreen(
             exploreUiState = exploreUiState,
             onQueryChange = viewModel::onTextInputChanged,
             onUniversitySelect = viewModel::onUniversitySelected,
+            onClearRecentSearches = viewModel::onClearRecentSearches,
         )
     }
 }
@@ -81,6 +83,7 @@ fun ExploreSearchScreen(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -106,6 +109,7 @@ fun ExploreSearchScreen(
                 exploreUiState = exploreUiState,
                 onQueryChange = onQueryChange,
                 onUniversitySelect = onUniversitySelect,
+                onClearRecentSearches = onClearRecentSearches,
             )
         }
     }
@@ -117,6 +121,7 @@ fun ExploreLandingScreen(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -170,6 +175,7 @@ fun ExploreLandingScreen(
                     isSearchMode = isSearchMode,
                     exploreUiState = exploreUiState,
                     onUniversitySelect = onUniversitySelect,
+                    onClearRecentSearches = onClearRecentSearches,
                 )
 
                 Spacer(modifier = Modifier.weight(0.7f))
@@ -188,6 +194,7 @@ private fun ExploreSearchScreenPreview() {
             onQueryChange = {},
             onUniversitySelect = {},
             onBackClick = {},
+            onClearRecentSearches = {},
         )
     }
 }
@@ -201,6 +208,7 @@ private fun ExploreLandingScreenPreview() {
             exploreUiState = ExploreUiState(searchState = SearchUiState.Idle),
             onQueryChange = {},
             onUniversitySelect = {},
+            onClearRecentSearches = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
@@ -65,6 +65,7 @@ fun ExploreScreen(
             onUniversitySelect = viewModel::onUniversitySelected,
             onBackClick = onBackClick,
             onClearRecentSearches = viewModel::onClearRecentSearches,
+            onUniversityDelete = viewModel::onRecentSearchDelete,
         )
     } else {
         ExploreLandingScreen(
@@ -73,6 +74,7 @@ fun ExploreScreen(
             onQueryChange = viewModel::onTextInputChanged,
             onUniversitySelect = viewModel::onUniversitySelected,
             onClearRecentSearches = viewModel::onClearRecentSearches,
+            onUniversityDelete = viewModel::onRecentSearchDelete,
         )
     }
 }
@@ -83,6 +85,7 @@ fun ExploreSearchScreen(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
     onClearRecentSearches: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -110,6 +113,7 @@ fun ExploreSearchScreen(
                 onQueryChange = onQueryChange,
                 onUniversitySelect = onUniversitySelect,
                 onClearRecentSearches = onClearRecentSearches,
+                onUniversityDelete = onUniversityDelete,
             )
         }
     }
@@ -121,6 +125,7 @@ fun ExploreLandingScreen(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
     onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -176,6 +181,7 @@ fun ExploreLandingScreen(
                     exploreUiState = exploreUiState,
                     onUniversitySelect = onUniversitySelect,
                     onClearRecentSearches = onClearRecentSearches,
+                    onUniversityDelete = onUniversityDelete,
                 )
 
                 Spacer(modifier = Modifier.weight(0.7f))
@@ -195,6 +201,7 @@ private fun ExploreSearchScreenPreview() {
             onUniversitySelect = {},
             onBackClick = {},
             onClearRecentSearches = {},
+            onUniversityDelete = {},
         )
     }
 }
@@ -209,6 +216,7 @@ private fun ExploreLandingScreenPreview() {
             onQueryChange = {},
             onUniversitySelect = {},
             onClearRecentSearches = {},
+            onUniversityDelete = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreScreen.kt
@@ -1,10 +1,5 @@
 package com.daedan.festabook.presentation.explore.component
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -27,6 +22,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daedan.festabook.presentation.explore.ExploreSideEffect
+import com.daedan.festabook.presentation.explore.ExploreUiState
 import com.daedan.festabook.presentation.explore.ExploreViewModel
 import com.daedan.festabook.presentation.explore.SearchUiState
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
@@ -44,7 +40,7 @@ fun ExploreScreen(
     onBackClick: () -> Unit,
     viewModel: ExploreViewModel,
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val exploreUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val latestNavigateToMain by rememberUpdatedState(onNavigateToMain)
@@ -61,18 +57,18 @@ fun ExploreScreen(
         }
     }
 
-    if (uiState.hasFestivalId) {
+    if (exploreUiState.hasFestivalId) {
         ExploreSearchScreen(
-            query = uiState.query,
-            searchState = uiState.searchState,
+            query = exploreUiState.query,
+            exploreUiState = exploreUiState,
             onQueryChange = viewModel::onTextInputChanged,
             onUniversitySelect = viewModel::onUniversitySelected,
             onBackClick = onBackClick,
         )
     } else {
         ExploreLandingScreen(
-            query = uiState.query,
-            searchState = uiState.searchState,
+            query = exploreUiState.query,
+            exploreUiState = exploreUiState,
             onQueryChange = viewModel::onTextInputChanged,
             onUniversitySelect = viewModel::onUniversitySelected,
         )
@@ -82,7 +78,7 @@ fun ExploreScreen(
 @Composable
 fun ExploreSearchScreen(
     query: String,
-    searchState: SearchUiState,
+    exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
     onBackClick: () -> Unit,
@@ -107,7 +103,7 @@ fun ExploreSearchScreen(
         ) {
             ExploreSearchContent(
                 query = query,
-                searchState = searchState,
+                exploreUiState = exploreUiState,
                 onQueryChange = onQueryChange,
                 onUniversitySelect = onUniversitySelect,
             )
@@ -118,13 +114,13 @@ fun ExploreSearchScreen(
 @Composable
 fun ExploreLandingScreen(
     query: String,
-    searchState: SearchUiState,
+    exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    val isError = searchState.shouldShowErrorUi
+    val isError = exploreUiState.searchState.shouldShowErrorUi
 
     val isSearchMode = query.isNotBlank()
 
@@ -166,30 +162,15 @@ fun ExploreLandingScreen(
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
-                ExploreSearchBar(
+                ExploreLandingContent(
                     query = query,
                     onQueryChange = onQueryChange,
-                    onSearch = { keyboardController?.hide() },
+                    keyboardController = keyboardController,
                     isError = isError,
-                    modifier = Modifier.padding(horizontal = 20.dp),
+                    isSearchMode = isSearchMode,
+                    exploreUiState = exploreUiState,
+                    onUniversitySelect = onUniversitySelect,
                 )
-
-                AnimatedContent(
-                    targetState = isSearchMode,
-                    transitionSpec = {
-                        ContentTransform(
-                            targetContentEnter = fadeIn(tween(200)),
-                            initialContentExit = fadeOut(tween(200)),
-                        )
-                    },
-                ) { searching ->
-                    if (searching) {
-                        ExploreSearchResultList(
-                            searchState = searchState,
-                            onUniversitySelect = onUniversitySelect,
-                        )
-                    }
-                }
 
                 Spacer(modifier = Modifier.weight(0.7f))
             }
@@ -203,7 +184,7 @@ private fun ExploreSearchScreenPreview() {
     FestabookTheme {
         ExploreSearchScreen(
             query = "서울",
-            searchState = SearchUiState.Idle,
+            exploreUiState = ExploreUiState(searchState = SearchUiState.Idle),
             onQueryChange = {},
             onUniversitySelect = {},
             onBackClick = {},
@@ -217,7 +198,7 @@ private fun ExploreLandingScreenPreview() {
     FestabookTheme {
         ExploreLandingScreen(
             query = "ㅇㄹㅇ",
-            searchState = SearchUiState.Idle,
+            exploreUiState = ExploreUiState(searchState = SearchUiState.Idle),
             onQueryChange = {},
             onUniversitySelect = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
@@ -20,6 +20,7 @@ fun ExploreSearchContent(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -42,6 +43,7 @@ fun ExploreSearchContent(
         ExploreSearchResultList(
             exploreUiState = exploreUiState,
             onUniversitySelect = onUniversitySelect,
+            onClearRecentSearches = onClearRecentSearches,
             modifier = Modifier.weight(1f),
         )
     }
@@ -65,6 +67,7 @@ private fun ExploreSearchContentPreview() {
                 ),
             onQueryChange = {},
             onUniversitySelect = {},
+            onClearRecentSearches = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.ExploreUiState
 import com.daedan.festabook.presentation.explore.SearchUiState
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
 import com.daedan.festabook.presentation.theme.FestabookTheme
@@ -16,13 +17,13 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun ExploreSearchContent(
     query: String,
-    searchState: SearchUiState,
+    exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    val isError = searchState.shouldShowErrorUi
+    val isError = exploreUiState.searchState.shouldShowErrorUi
 
     Column(
         modifier =
@@ -39,7 +40,7 @@ fun ExploreSearchContent(
         }
 
         ExploreSearchResultList(
-            searchState = searchState,
+            exploreUiState = exploreUiState,
             onUniversitySelect = onUniversitySelect,
             modifier = Modifier.weight(1f),
         )
@@ -52,12 +53,15 @@ private fun ExploreSearchContentPreview() {
     FestabookTheme {
         ExploreSearchContent(
             query = "서울",
-            searchState =
-                SearchUiState.Success(
-                    listOf(
-                        SearchResultUiModel(1, "서울시립대학교", "2024 대동제"),
-                        SearchResultUiModel(2, "서울대학교", "2024 봄축제"),
-                    ),
+            exploreUiState =
+                ExploreUiState(
+                    searchState =
+                        SearchUiState.Success(
+                            listOf(
+                                SearchResultUiModel(1, "서울시립대학교", "2024 대동제"),
+                                SearchResultUiModel(2, "서울대학교", "2024 봄축제"),
+                            ),
+                        ),
                 ),
             onQueryChange = {},
             onUniversitySelect = {},

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchContent.kt
@@ -20,6 +20,7 @@ fun ExploreSearchContent(
     exploreUiState: ExploreUiState,
     onQueryChange: (String) -> Unit,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
     onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -44,6 +45,7 @@ fun ExploreSearchContent(
             exploreUiState = exploreUiState,
             onUniversitySelect = onUniversitySelect,
             onClearRecentSearches = onClearRecentSearches,
+            onUniversityDelete = onUniversityDelete,
             modifier = Modifier.weight(1f),
         )
     }
@@ -68,6 +70,7 @@ private fun ExploreSearchContentPreview() {
             onQueryChange = {},
             onUniversitySelect = {},
             onClearRecentSearches = {},
+            onUniversityDelete = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
@@ -22,6 +22,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 fun ExploreSearchResultList(
     exploreUiState: ExploreUiState,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onUniversityDelete: (SearchResultUiModel) -> Unit,
     onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -59,9 +60,10 @@ fun ExploreSearchResultList(
 
             is SearchUiState.Idle -> {
                 item {
-                    RecentSearchTitle(
+                    RecentSearchMessageView(
                         onClick = onClearRecentSearches,
                         modifier = Modifier.padding(bottom = 10.dp),
+                        isExist = exploreUiState.recentSearches.isNotEmpty(),
                     )
                 }
                 items(
@@ -71,6 +73,8 @@ fun ExploreSearchResultList(
                     ExploreResultItem(
                         university = recentSearch,
                         onItemClick = onUniversitySelect,
+                        canDelete = true,
+                        onDeleteClick = onUniversityDelete,
                     )
                 }
             }
@@ -86,6 +90,7 @@ private fun ExploreSearchResultListLoadingPreview() {
             exploreUiState = ExploreUiState(searchState = SearchUiState.Loading),
             onUniversitySelect = {},
             onClearRecentSearches = {},
+            onUniversityDelete = {},
         )
     }
 }
@@ -109,6 +114,7 @@ private fun ExploreSearchResultListSuccessPreview() {
                 ),
             onUniversitySelect = {},
             onClearRecentSearches = {},
+            onUniversityDelete = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
@@ -61,7 +61,7 @@ fun ExploreSearchResultList(
             is SearchUiState.Idle -> {
                 item {
                     RecentSearchMessageView(
-                        onClick = onClearRecentSearches,
+                        onClearAllClick = onClearRecentSearches,
                         modifier = Modifier.padding(bottom = 10.dp),
                         isExist = exploreUiState.recentSearches.isNotEmpty(),
                     )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
@@ -22,16 +22,16 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 fun ExploreSearchResultList(
     exploreUiState: ExploreUiState,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
+    onClearRecentSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val searchUiState = exploreUiState.searchState
     LazyColumn(
         modifier =
             modifier
                 .fillMaxSize()
                 .padding(horizontal = 20.dp),
     ) {
-        when (searchUiState) {
+        when (val searchUiState = exploreUiState.searchState) {
             is SearchUiState.Loading -> {
                 item {
                     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
@@ -59,7 +59,10 @@ fun ExploreSearchResultList(
 
             is SearchUiState.Idle -> {
                 item {
-                    RecentSearchTitle(onClick = { }, modifier = Modifier.padding(bottom = 10.dp))
+                    RecentSearchTitle(
+                        onClick = onClearRecentSearches,
+                        modifier = Modifier.padding(bottom = 10.dp),
+                    )
                 }
                 items(
                     items = exploreUiState.recentSearches,
@@ -82,6 +85,7 @@ private fun ExploreSearchResultListLoadingPreview() {
         ExploreSearchResultList(
             exploreUiState = ExploreUiState(searchState = SearchUiState.Loading),
             onUniversitySelect = {},
+            onClearRecentSearches = {},
         )
     }
 }
@@ -104,6 +108,7 @@ private fun ExploreSearchResultListSuccessPreview() {
                         ),
                 ),
             onUniversitySelect = {},
+            onClearRecentSearches = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/ExploreSearchResultList.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.explore.ExploreUiState
 import com.daedan.festabook.presentation.explore.SearchUiState
 import com.daedan.festabook.presentation.explore.model.SearchResultUiModel
 import com.daedan.festabook.presentation.theme.FestabookColor
@@ -19,17 +20,18 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ExploreSearchResultList(
-    searchState: SearchUiState,
+    exploreUiState: ExploreUiState,
     onUniversitySelect: (SearchResultUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val searchUiState = exploreUiState.searchState
     LazyColumn(
         modifier =
             modifier
                 .fillMaxSize()
                 .padding(horizontal = 20.dp),
     ) {
-        when (searchState) {
+        when (searchUiState) {
             is SearchUiState.Loading -> {
                 item {
                     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
@@ -42,7 +44,10 @@ fun ExploreSearchResultList(
             }
 
             is SearchUiState.Success -> {
-                items(searchState.universitiesFound) { university ->
+                items(
+                    items = searchUiState.universitiesFound,
+                    key = { it.festivalId },
+                ) { university ->
                     ExploreResultItem(
                         university = university,
                         onItemClick = onUniversitySelect,
@@ -52,7 +57,20 @@ fun ExploreSearchResultList(
 
             is SearchUiState.Error -> {}
 
-            is SearchUiState.Idle -> {}
+            is SearchUiState.Idle -> {
+                item {
+                    RecentSearchTitle(onClick = { }, modifier = Modifier.padding(bottom = 10.dp))
+                }
+                items(
+                    items = exploreUiState.recentSearches,
+                    key = { it.festivalId },
+                ) { recentSearch ->
+                    ExploreResultItem(
+                        university = recentSearch,
+                        onItemClick = onUniversitySelect,
+                    )
+                }
+            }
         }
     }
 }
@@ -62,7 +80,7 @@ fun ExploreSearchResultList(
 private fun ExploreSearchResultListLoadingPreview() {
     FestabookTheme {
         ExploreSearchResultList(
-            searchState = SearchUiState.Loading,
+            exploreUiState = ExploreUiState(searchState = SearchUiState.Loading),
             onUniversitySelect = {},
         )
     }
@@ -78,9 +96,12 @@ private fun ExploreSearchResultListSuccessPreview() {
         )
     FestabookTheme {
         ExploreSearchResultList(
-            searchState =
-                SearchUiState.Success(
-                    universitiesFound = fakeUniversities,
+            exploreUiState =
+                ExploreUiState(
+                    searchState =
+                        SearchUiState.Success(
+                            universitiesFound = fakeUniversities,
+                        ),
                 ),
             onUniversitySelect = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
@@ -22,12 +22,12 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun RecentSearchMessageView(
-    onClick: () -> Unit,
+    onClearAllClick: () -> Unit,
     isExist: Boolean,
     modifier: Modifier = Modifier,
 ) {
     if (isExist) {
-        RecentSearchTitle(modifier = modifier, onClick = onClick)
+        RecentSearchTitle(modifier = modifier, onClearAllClick = onClearAllClick)
     } else {
         NoRecentSearchTitle(modifier = modifier)
     }
@@ -35,7 +35,7 @@ fun RecentSearchMessageView(
 
 @Composable
 private fun RecentSearchTitle(
-    onClick: () -> Unit,
+    onClearAllClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -48,7 +48,7 @@ private fun RecentSearchTitle(
             style = FestabookTypography.titleLarge,
             color = FestabookColor.gray800,
         )
-        TextButton(onClick = onClick, contentPadding = PaddingValues(0.dp)) {
+        TextButton(onClick = onClearAllClick, contentPadding = PaddingValues(0.dp)) {
             Text(
                 text = stringResource(Res.string.clear_all),
                 style = FestabookTypography.bodyLarge,
@@ -72,5 +72,5 @@ private fun NoRecentSearchTitle(modifier: Modifier = Modifier) {
 @Composable
 @Preview(showBackground = true)
 private fun RecentSearchTitlePreview() {
-    RecentSearchMessageView(onClick = {}, isExist = false)
+    RecentSearchMessageView(onClearAllClick = {}, isExist = false)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.presentation.explore.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,14 +15,28 @@ import com.daedan.festabook.presentation.theme.FestabookColor
 import com.daedan.festabook.presentation.theme.FestabookTypography
 import festabookkmp.composeapp.generated.resources.Res
 import festabookkmp.composeapp.generated.resources.clear_all
+import festabookkmp.composeapp.generated.resources.no_recent_searches_message
 import festabookkmp.composeapp.generated.resources.recent_searches
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun RecentSearchTitle(
+fun RecentSearchMessageView(
     onClick: () -> Unit,
+    isExist: Boolean,
     modifier: Modifier = Modifier,
+) {
+    if (isExist) {
+        RecentSearchTitle(modifier = modifier, onClick = onClick)
+    } else {
+        NoRecentSearchTitle(modifier = modifier)
+    }
+}
+
+@Composable
+private fun RecentSearchTitle(
+    modifier: Modifier,
+    onClick: () -> Unit,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -44,7 +59,18 @@ fun RecentSearchTitle(
 }
 
 @Composable
+private fun NoRecentSearchTitle(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Text(
+            text = stringResource(Res.string.no_recent_searches_message),
+            style = FestabookTypography.bodyLarge,
+            color = FestabookColor.gray800,
+        )
+    }
+}
+
+@Composable
 @Preview(showBackground = true)
 private fun RecentSearchTitlePreview() {
-    RecentSearchTitle(onClick = {})
+    RecentSearchMessageView(onClick = {}, isExist = false)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchMessageView.kt
@@ -35,8 +35,8 @@ fun RecentSearchMessageView(
 
 @Composable
 private fun RecentSearchTitle(
-    modifier: Modifier,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchTitle.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/component/RecentSearchTitle.kt
@@ -1,0 +1,50 @@
+package com.daedan.festabook.presentation.explore.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.presentation.theme.FestabookColor
+import com.daedan.festabook.presentation.theme.FestabookTypography
+import festabookkmp.composeapp.generated.resources.Res
+import festabookkmp.composeapp.generated.resources.clear_all
+import festabookkmp.composeapp.generated.resources.recent_searches
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun RecentSearchTitle(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = stringResource(Res.string.recent_searches),
+            style = FestabookTypography.titleLarge,
+            color = FestabookColor.gray800,
+        )
+        TextButton(onClick = onClick, contentPadding = PaddingValues(0.dp)) {
+            Text(
+                text = stringResource(Res.string.clear_all),
+                style = FestabookTypography.bodyLarge,
+                color = FestabookColor.gray800,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun RecentSearchTitlePreview() {
+    RecentSearchTitle(onClick = {})
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/model/SearchResultUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/explore/model/SearchResultUiModel.kt
@@ -14,3 +14,12 @@ fun FestivalSearchItem.toUiModel(): SearchResultUiModel =
         universityName = organizationName,
         festivalName = festivalName.replace("\n", " "),
     )
+
+fun SearchResultUiModel.toDomain(): FestivalSearchItem =
+    FestivalSearchItem(
+        festivalId = festivalId,
+        organizationName = universityName,
+        festivalName = festivalName,
+        startDate = "",
+        endDate = "",
+    )

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/explore/ExploreViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/explore/ExploreViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.daedan.festabook.explore
+package com.daedan.festabook.viewModel.explore
 
 import com.daedan.festabook.domain.model.FestivalSearchItem
 import com.daedan.festabook.domain.repository.ExploreRepository
@@ -15,11 +15,10 @@ import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -32,7 +31,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ExploreViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var exploreRepository: ExploreRepository
     private lateinit var exploreViewModel: ExploreViewModel
 
@@ -41,6 +40,7 @@ class ExploreViewModelTest {
         Dispatchers.setMain(testDispatcher)
         exploreRepository = mock(MockMode.autofill)
         everySuspend { exploreRepository.search(any()) } returns Result.success(emptyList())
+        everySuspend { exploreRepository.getRecentFestivalSearches() } returns flowOf(emptyList())
     }
 
     @AfterTest
@@ -53,10 +53,8 @@ class ExploreViewModelTest {
         runTest {
             // given
             everySuspend { exploreRepository.getFestivalId() } returns 1L
-
             // when
             exploreViewModel = ExploreViewModel(exploreRepository)
-            advanceUntilIdle()
 
             // then
             verifySuspend { exploreRepository.getFestivalId() }
@@ -72,7 +70,6 @@ class ExploreViewModelTest {
 
             // when
             exploreViewModel.onTextInputChanged(query)
-            advanceUntilIdle()
 
             // then
             assertEquals(query, exploreViewModel.uiState.value.query)
@@ -108,7 +105,6 @@ class ExploreViewModelTest {
             // when
             exploreViewModel.onTextInputChanged(query)
             advanceTimeBy(500L)
-            advanceUntilIdle()
 
             // then
             verifySuspend { exploreRepository.search(query) }
@@ -124,12 +120,10 @@ class ExploreViewModelTest {
             exploreViewModel = ExploreViewModel(exploreRepository)
             exploreViewModel.onTextInputChanged("이전검색어")
             advanceTimeBy(500L)
-            advanceUntilIdle()
 
             // when
             exploreViewModel.onTextInputChanged("")
             advanceTimeBy(500L)
-            advanceUntilIdle()
 
             // then
             assertEquals(SearchUiState.Idle, exploreViewModel.uiState.value.searchState)
@@ -147,7 +141,6 @@ class ExploreViewModelTest {
             // when
             exploreViewModel.onTextInputChanged(query)
             advanceTimeBy(500L)
-            advanceUntilIdle()
 
             // then
             verifySuspend { exploreRepository.search(query) }
@@ -178,7 +171,6 @@ class ExploreViewModelTest {
 
             // when
             exploreViewModel.onUniversitySelected(searchResult)
-            advanceUntilIdle()
 
             // then
             verifySuspend { exploreRepository.saveFestivalId(searchResult.festivalId) }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -38,8 +38,6 @@
 		};
 		8E6C8D378651BF8144E66D20 /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
@@ -287,10 +285,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosAppDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L8HZU9MP64;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -306,8 +306,9 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = eoehdeksruf.festabook.debug;
+				PRODUCT_BUNDLE_IDENTIFIER = debug.eoehdeksruf.festabook;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = festabook_development_debug_provisioning_profile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -386,7 +387,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = festabook;
+				INFOPLIST_KEY_CFBundleDisplayName = "festabook(Debug)";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "현재 위치를 지도에 표시하고 가까운 장소를 찾기 위해 위치 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -1,30 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>CFBundleName</key>
-        <string>festabook</string>
-
-        <key>CADisableMinimumFrameDurationOnPhone</key>
-        <true />
-
-        <key>CFBundleShortVersionString</key>
-		<string>2.1.0</string>
-
-        <key>CFBundleVersion</key>
-		<string>20100</string>
-
-        <key>CADisableMinimumFrameDurationOnPhone</key>
-        <true />
-        <key>LSApplicationQueriesSchemes</key>
-        <array>
-            <string>itms-apps</string>
-        </array>
-        <key>UIBackgroundModes</key>
-        <array>
-            <string>remote-notification</string>
-        </array>
-        <key>FirebaseAppDelegateProxyEnabled</key>
-        <false/>
-    </dict>
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-apps</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+</dict>
 </plist>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -14,5 +14,9 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+<key>CFBundleShortVersionString</key>
+		<string>2.1.0</string>
+<key>CFBundleVersion</key>
+		<string>20100</string>
 </dict>
 </plist>


### PR DESCRIPTION
## #️⃣ 이슈 번호

#101 

<br>

## 🛠️ 작업 내용

- 최근 검색어 저장 기능 추가
- 전체 삭제 기능 추가
- 부분 삭제 기능 추가
- 로컬 DataStore에 저장하고 삭제하는 로직을 추가했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 예외처리 부분이 아직 미흡한데 개선사항 있으시면 환영입니다!

<br>

## 📸 이미지 첨부 (Optional)



https://github.com/user-attachments/assets/7b04b667-e6f7-4020-9e6f-d8947d4a29d8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 최근 검색한 축제 저장, 표시, 삭제(개별/전체) 기능 추가
  * 검색 화면에 최근검색 UI 및 관련 상호작용(삭제, 전체삭제) 추가
  * 검색 결과 항목에서 삭제 버튼 표시 및 동작 지원
  * 한국어 문자열 리소스(최근검색 레이블, 전체삭제, 빈상태 메시지, 닫기 설명) 추가

* **기타**
  * iOS 앱 빌드 설정 및 Info.plist 정리/조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->