### PR TITLE
[Fix] ios에서 홈 화면에서 뒤로가기 시, 스낵바가 노출되는 버그 해결

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/Platform.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/Platform.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook
+
+actual fun getPlatform(): Platform = Platform.ANDROID

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationEndpoint.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationEndpoint.android.kt
@@ -1,3 +1,0 @@
-package com.daedan.festabook.data.service.platform
-
-actual fun festivalNotificationPlatform(): String = "android"

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/Platform.kt
@@ -1,0 +1,8 @@
+package com.daedan.festabook
+
+expect fun getPlatform(): Platform
+
+enum class Platform {
+    ANDROID,
+    IOS,
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceImpl.kt
@@ -1,11 +1,12 @@
 package com.daedan.festabook.data.datasource.remote.festival
 
+import com.daedan.festabook.Platform
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.model.request.FestivalNotificationRequest
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
 import com.daedan.festabook.data.model.response.festival.RegisteredFestivalNotificationResponse
 import com.daedan.festabook.data.service.FestivalNotificationService
-import com.daedan.festabook.data.service.platform.festivalNotificationPlatform
+import com.daedan.festabook.getPlatform
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -22,7 +23,7 @@ class FestivalNotificationRemoteDataSourceImpl(
         ApiResult.toApiResult {
             festivalNotificationService.saveFestivalNotification(
                 festivalId,
-                festivalNotificationPlatform(),
+                platform,
                 FestivalNotificationRequest(deviceId = deviceId),
             )
         }
@@ -36,4 +37,12 @@ class FestivalNotificationRemoteDataSourceImpl(
         ApiResult.toApiResult {
             festivalNotificationService.getFestivalNotification(deviceId)
         }
+
+    companion object {
+        private val platform =
+            when (getPlatform()) {
+                Platform.ANDROID -> "android"
+                Platform.IOS -> "ios"
+            }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationPlatform.kt
@@ -1,3 +1,0 @@
-package com.daedan.festabook.data.service.platform
-
-expect fun festivalNotificationPlatform(): String

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -15,7 +15,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
+import com.daedan.festabook.Platform
 import com.daedan.festabook.di.FestabookAppGraph
+import com.daedan.festabook.getPlatform
 import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.common.ObserveAsEvents
 import com.daedan.festabook.presentation.common.component.FestabookSnackbar
@@ -96,7 +98,9 @@ fun MainScreen(
     NavigationBackHandler(
         state = state,
     ) {
-        mainViewModel.onBackPressed()
+        if (getPlatform() == Platform.ANDROID) {
+            mainViewModel.onBackPressed()
+        }
     }
 
     RememberDeepLinkHandler { intent ->

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalNotificationRemoteDataSourceTest.kt
@@ -1,11 +1,12 @@
 package com.daedan.festabook.data.datasource.remote.festival
 
+import com.daedan.festabook.Platform
 import com.daedan.festabook.data.datasource.remote.ApiResult
 import com.daedan.festabook.data.datasource.remote.schedule.FAKE_HTTP_RESPONSE
 import com.daedan.festabook.data.model.request.FestivalNotificationRequest
 import com.daedan.festabook.data.model.response.festival.FestivalNotificationResponse
 import com.daedan.festabook.data.service.FestivalNotificationService
-import com.daedan.festabook.data.service.platform.festivalNotificationPlatform
+import com.daedan.festabook.getPlatform
 import de.jensklingenberg.ktorfit.Response
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
@@ -35,6 +36,12 @@ private val FAKE_DELETE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE: Response<Unit> =
         body = Unit,
     ) as Response<Unit>
 
+private val ENDPOINT =
+    when (getPlatform()) {
+        Platform.ANDROID -> "android"
+        Platform.IOS -> "ios"
+    }
+
 class FestivalNotificationRemoteDataSourceTest {
     private lateinit var festivalNotificationService: FestivalNotificationService
     private lateinit var dataSource: FestivalNotificationRemoteDataSource
@@ -54,10 +61,16 @@ class FestivalNotificationRemoteDataSourceTest {
 
             val request = FestivalNotificationRequest(deviceId = deviceId)
 
+            val endPoint =
+                when (getPlatform()) {
+                    Platform.ANDROID -> "android"
+                    Platform.IOS -> "ios"
+                }
+
             everySuspend {
                 festivalNotificationService.saveFestivalNotification(
                     festivalId,
-                    festivalNotificationPlatform(),
+                    ENDPOINT,
                     request,
                 )
             } returns FAKE_SAVE_FESTIVAL_NOTIFICATION_HTTP_RESPONSE
@@ -70,7 +83,7 @@ class FestivalNotificationRemoteDataSourceTest {
             verifySuspend {
                 festivalNotificationService.saveFestivalNotification(
                     festivalId,
-                    festivalNotificationPlatform(),
+                    ENDPOINT,
                     request,
                 )
             }

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/Platform.ios.kt
@@ -1,0 +1,3 @@
+package com.daedan.festabook
+
+actual fun getPlatform(): Platform = Platform.IOS

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationEndpoint.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/data/service/platform/FestivalNotificationEndpoint.ios.kt
@@ -1,3 +1,0 @@
-package com.daedan.festabook.data.service.platform
-
-actual fun festivalNotificationPlatform(): String = "ios"


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #116 

<br>

## 🛠️ 작업 내용

- ios에서 홈 화면에서 뒤로가기 시, 스낵바가 노출되는 버그를 해결했습니다

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선 사항**
  * 플랫폼 감지 메커니즘을 최적화하여 Android와 iOS 간의 더 일관된 동작을 구현했습니다.
  * 뒤로 가기 동작이 Android에서 더 정확하게 처리되도록 개선했습니다.

* **테스트**
  * 업데이트된 플랫폼 감지 로직에 맞게 테스트를 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->