### PR TITLE
[Fix]: MainScreen 내 네비게이션 전환 애니메이션 제거

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -1,5 +1,7 @@
 package com.daedan.festabook.presentation.main.component
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -196,6 +198,8 @@ private fun FestabookNavHost(
         modifier = modifier,
         startDestination = navigator.startRoute,
         navController = navigator.navController,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
     ) {
         homeNavGraph(
             viewModel = homeViewModel,


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #117

<br>

## 🛠️ 작업 내용

- ios에서 메인 탭에서 슬라이드 전환 애니메이션이 불규칙한 버그를 해결했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 메인 탭 슬라이드 전환 애니메이션을 완전히 제거했는데, 더 좋은 방향이 있다면 의견 부탁드려요!

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
