### PR TITLE
[Chore] GitHub Actions self-hosted runner 전환

### DIFF
--- a/.github/workflows/android-release-drafter.yml
+++ b/.github/workflows/android-release-drafter.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   Upload-Release-Bundle:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       version_code: ${{ steps.get_version.outputs.version_code }}
 
@@ -79,7 +79,7 @@ jobs:
 
   #번들이 업로드가 완료된 후 버전 태그를 작성합니다
   Release-Drafter:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: Upload-Release-Bundle
 
     steps:
@@ -98,7 +98,7 @@ jobs:
   # hotfix 머지 시, main의 변경사항을 develop에 자동 반영합니다
   # 번들이 업로드가 완료된 후 실행됩니다
   Reflect-Changes-Into-Develop:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: Upload-Release-Bundle
 
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/cmp-ci.yml
+++ b/.github/workflows/cmp-ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Publish Unit Test Results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           # 결과 리포트 경로 수정 (composeApp 모듈 기준)
           files: composeApp/build/test-results/**/*.xml

--- a/.github/workflows/cmp-ci.yml
+++ b/.github/workflows/cmp-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Run-PR-Test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       contents: read

--- a/.github/workflows/cmp-ci.yml
+++ b/.github/workflows/cmp-ci.yml
@@ -26,6 +26,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+
       - name: Gradle cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/common-slack-notify-opened.yml
+++ b/.github/workflows/common-slack-notify-opened.yml
@@ -13,7 +13,7 @@ concurrency:
 # 최초 리뷰 요청 알림
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       # JSON 파싱 도구
       - name: Install jq

--- a/.github/workflows/common-slack-notify-rerequested.yml
+++ b/.github/workflows/common-slack-notify-rerequested.yml
@@ -15,7 +15,7 @@ concurrency:
 # 재리뷰 요청 알림
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       # JSON 파싱 도구
       - name: Install jq

--- a/.github/workflows/common-slack-notify-submitted.yml
+++ b/.github/workflows/common-slack-notify-submitted.yml
@@ -13,7 +13,7 @@ concurrency:
 # 리뷰 완료 알림
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
## 개요
GitHub-hosted runner를 사용할 수 없게 되어, 모든 워크플로우의 `runs-on`을 `self-hosted`로 전환합니다.

## 변경 사항
- 7개 워크플로우 파일의 `runs-on: ubuntu-latest` → `runs-on: self-hosted` 변경
  - `android-release-drafter.yml` (3곳)
  - `claude-code-review.yml`
  - `claude.yml`
  - `cmp-ci.yml`
  - `common-slack-notify-opened.yml`
  - `common-slack-notify-rerequested.yml`
  - `common-slack-notify-submitted.yml`

## 변경 이유
GitHub-hosted runner 사용이 불가하여 self-hosted runner로 전환 필요

## 테스트 방법
- [ ] self-hosted runner가 정상 등록되어 있는지 확인
- [ ] PR 생성 시 CI 워크플로우가 self-hosted runner에서 실행되는지 확인

## 관련 이슈
closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 여러 GitHub Actions 워크플로우의 실행 환경을 GitHub 호스팅 러너(ubuntu-latest)에서 셀프 호스팅 러너로 변경했습니다. 워크플로우 로직과 단계는 유지됩니다.
  * PR 테스트 워크플로우에 Android 도구 설치/설정 단계가 추가되어 Android 빌드 준비가 자동화됩니다.
  * CI용 단위 테스트 결과 게시 액션이 러너 환경에 맞는 변형으로 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->