### PR TITLE
[Fix]: 웨이팅 정보 등록 화면 키보드 노출 시 확인 버튼 가림 현상 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/waitinginfo/component/AddWaitingInfoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/waitinginfo/component/AddWaitingInfoScreen.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.presentation.setting.waitinginfo.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +13,9 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Button
@@ -37,7 +40,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.input.ImeAction
@@ -135,6 +140,7 @@ fun AddWaitingInfoScreen(
 ) {
     val windowInfo = LocalWindowInfo.current
     val density = LocalDensity.current
+    val focusManager = LocalFocusManager.current
     val screenWidthDp =
         remember {
             with(density) {
@@ -174,7 +180,9 @@ fun AddWaitingInfoScreen(
                 Modifier
                     .fillMaxSize()
                     .background(FestabookColor.white)
-                    .padding(innerPadding)
+                    .pointerInput(Unit) {
+                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                    }.padding(innerPadding)
                     .imePadding(),
         ) {
             Spacer(modifier = Modifier.height(festabookSpacing.paddingBody5))
@@ -194,7 +202,9 @@ fun AddWaitingInfoScreen(
             Column(
                 modifier =
                     Modifier
-                        .fillMaxSize()
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
                         .padding(horizontal = festabookSpacing.paddingScreenGutter),
             ) {
                 AddPhoneNumberContent(
@@ -215,16 +225,15 @@ fun AddWaitingInfoScreen(
                     isTermsAgreed = isTermsAgreed,
                     onTermsAgreedChange = onTermsAgreedChange,
                 )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                ConfirmButton(
-                    phoneNumber = phoneNumber,
-                    isSaveEnabled = isSaveEnabled,
-                    isSaving = isSaving,
-                    onSaveClick = onSaveClick,
-                )
             }
+
+            ConfirmButton(
+                phoneNumber = phoneNumber,
+                isSaveEnabled = isSaveEnabled,
+                isSaving = isSaving,
+                onSaveClick = onSaveClick,
+                modifier = Modifier.padding(horizontal = festabookSpacing.paddingScreenGutter),
+            )
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #138 

<br>

## 🛠️ 작업 내용

- 웨이팅 정보 등록 호면 키보드 노출 시, 버튼을 가리는 버그를 해결했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)


https://github.com/user-attachments/assets/bc77efd6-e51e-4ac5-98e9-fddd4baeec6c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 배경을 탭할 때 자동으로 포커스를 해제하여 더 나은 사용자 경험 제공
  * 입력 영역이 이제 스크롤 가능하므로 긴 콘텐츠를 더 쉽게 탐색 가능
  * 확인 버튼이 항상 화면에 표시되므로 콘텐츠 스크롤 시에도 접근성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->