### PR TITLE
[Fix]: iOS FCM 푸시알림 관련 버그 수정

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -273,15 +273,6 @@ platform :android do
     apk = android_build(flavor: "release")
     android_upload(flavor: "release", apk_path: apk)
   end
-
-  error do |lane, exception|
-    notify_slack(
-      platform: "Android",
-      build_type: lane.to_s.include?("release") ? "Release" : "Dev",
-      success: false,
-      error: exception.message,
-    )
-  end
 end
 
 # --- iOS lanes ---
@@ -336,14 +327,5 @@ platform :ios do
       profile_name: local_property("IOS_PROVISIONING_PROFILE_RELEASE_NAME"),
     )
     ios_upload(configuration: "Release", bundle_id: bundle_id, ipa_path: ipa)
-  end
-
-  error do |lane, exception|
-    notify_slack(
-      platform: "iOS",
-      build_type: lane.to_s.include?("release") ? "Release" : "Dev",
-      success: false,
-      error: exception.message,
-    )
   end
 end

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -39,8 +39,6 @@
 		};
 		8E6C8D378651BF8144E66D20 /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
@@ -239,9 +237,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -347,13 +349,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				CODE_SIGN_ENTITLEMENTS = iosApp/iosAppDebug.entitlements;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosAppRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L8HZU9MP64;
+				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -395,6 +398,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = L8HZU9MP64;
+				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -486,10 +490,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosAppRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;

--- a/iosApp/iosApp/iosAppRelease.entitlements
+++ b/iosApp/iosApp/iosAppRelease.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+</dict>
+</plist>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #139

<br> 

## 🛠️ 작업 내용
- FCM 푸시알림 버그를 해결했습니다. 
- Staging/Release 빌드 시, 푸시 알림 entitlements 파일을 추가했습니다. 

## Staging 빌드에서 푸시 알림이 오지 않았던 이유 추정
- TestFlight와 같은 운영 환경에서는 apn-enviroment가 development로 설정되있는 경우, 푸시 알림이 수신되지 않는다는 리포트가 있습니다. 
참고: https://eigen.tistory.com/153

이를 보완하기 위해 release용 entitlement 파일을 추가하고 연동했습니다. 

추가적으로 빌드 시,enable_debug_dylib = no 를 추가하여, firebase 빌드 시 링커가 특정 심볼을 찾지 못하여 빌드가 실패하는 버그를 수정했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
