### PR TITLE
[Fix] 나의 웨이팅 하단 취소하기 바 배경색 추가

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/HomeViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daedan.festabook.di.viewmodel.ViewModelKey
 import com.daedan.festabook.domain.repository.FestivalRepository
-import com.daedan.festabook.presentation.home.model.toUiModel
 import com.daedan.festabook.domain.repository.MyWaitingRepository
+import com.daedan.festabook.presentation.home.model.toUiModel
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/component/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/component/HomeScreen.kt
@@ -26,12 +26,12 @@ import com.daedan.festabook.presentation.festating.component.FestatingPoster
 import com.daedan.festabook.presentation.home.FestivalUiState
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.LineupUiState
+import com.daedan.festabook.presentation.home.WaitingBarUiState
 import com.daedan.festabook.presentation.home.model.FestivalPosterUiModel
 import com.daedan.festabook.presentation.home.model.FestivalUiModel
 import com.daedan.festabook.presentation.home.model.LineUpItemGroupUiModel
 import com.daedan.festabook.presentation.home.model.LineupItemUiModel
 import com.daedan.festabook.presentation.home.model.OrganizationUiModel
-import com.daedan.festabook.presentation.home.WaitingBarUiState
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.daedan.festabook.presentation.theme.FestabookColor
 import com.daedan.festabook.presentation.theme.festabookSpacing

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
@@ -215,6 +215,7 @@ private fun MyWaitingContent(
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .background(FestabookColor.white)
                     .verticalScroll(rememberScrollState()),
         ) {
             Spacer(modifier = Modifier.height(16.dp))
@@ -279,12 +280,25 @@ private fun MyWaitingContent(
 
             Spacer(modifier = Modifier.height(100.dp))
         }
-        WaitingCancelButton(
-            isEnabled = !uiState.myWaiting.isCanceling,
-            isCancelling = uiState.myWaiting.isCanceling,
-            onClick = { showCancelConfirmDialog = true },
-            modifier = Modifier.align(Alignment.BottomCenter),
-        )
+        Column(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .requiredWidth(screenWidthDp)
+                    .background(FestabookColor.white),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            WaitingCancelButton(
+                modifier =
+                    Modifier.padding(
+                        vertical = festabookSpacing.paddingBody2,
+                        horizontal = festabookSpacing.paddingScreenGutter,
+                    ),
+                isEnabled = !uiState.myWaiting.isCanceling,
+                isCancelling = uiState.myWaiting.isCanceling,
+                onClick = { showCancelConfirmDialog = true },
+            )
+        }
     }
 }
 
@@ -377,9 +391,7 @@ private fun WaitingCancelButton(
     Box(
         modifier =
             modifier
-                .padding(
-                    vertical = festabookSpacing.paddingBody4,
-                ).fillMaxWidth()
+                .fillMaxWidth()
                 .height(52.dp)
                 .clip(festabookShapes.radius2)
                 .background(if (isEnabled) FestabookColor.black else FestabookColor.gray300)

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
@@ -290,10 +290,7 @@ private fun MyWaitingContent(
         ) {
             WaitingCancelButton(
                 modifier =
-                    Modifier.padding(
-                        vertical = festabookSpacing.paddingBody2,
-                        horizontal = festabookSpacing.paddingScreenGutter,
-                    ),
+                    Modifier.padding(festabookSpacing.paddingScreenGutter),
                 isEnabled = !uiState.myWaiting.isCanceling,
                 isCancelling = uiState.myWaiting.isCanceling,
                 onClick = { showCancelConfirmDialog = true },

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/home/HomeViewModelTest.kt
@@ -3,15 +3,15 @@ package com.daedan.festabook.viewModel.home
 import com.daedan.festabook.domain.model.MyWaiting
 import com.daedan.festabook.domain.model.WaitingStatus
 import com.daedan.festabook.domain.repository.FestivalRepository
+import com.daedan.festabook.domain.repository.MyWaitingRepository
 import com.daedan.festabook.home.FAKE_LINEUP
 import com.daedan.festabook.home.FAKE_ORGANIZATION
-import com.daedan.festabook.domain.repository.MyWaitingRepository
 import com.daedan.festabook.presentation.home.FestivalUiState
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.LineupUiState
+import com.daedan.festabook.presentation.home.WaitingBarUiState
 import com.daedan.festabook.presentation.home.model.LineUpItemOfDayUiModel
 import com.daedan.festabook.presentation.home.model.toUiModel
-import com.daedan.festabook.presentation.home.WaitingBarUiState
 import com.daedan.festabook.presentation.home.toUiModel
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #152 

<br>

## 🛠️ 작업 내용

- 하단 웨이팅 취소하기 바에 배경색을 추가하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 대기 화면의 취소 버튼 레이아웃을 개선하여 더 나은 화면 정렬과 여백 처리를 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->