### PR TITLE
[Feat]: 나의 웨이팅 화면 레이아웃 구조 개선 및 아티스트 아이템 이미지 컴포넌트 교체

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/component/HomeArtistItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/home/component/HomeArtistItem.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.daedan.festabook.presentation.common.component.CoilImage
+import com.daedan.festabook.presentation.common.component.FestabookImage
 import com.daedan.festabook.presentation.theme.FestabookColor
 import com.daedan.festabook.presentation.theme.FestabookTypography
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -28,9 +28,10 @@ fun HomeArtistItem(
     Column(
         modifier = modifier.width(68.dp),
     ) {
-        CoilImage(
-            url = artistImageUrl,
-            contentDescription = null,
+        FestabookImage(
+            imageUrl = artistImageUrl,
+            contentDescription = artistName,
+            enablePopUp = true,
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
@@ -34,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
@@ -114,11 +116,47 @@ fun MyWaitingScreen(
     val state = rememberNavigationEventState(NavigationEventInfo.None)
     NavigationBackHandler(state = state) { onBack() }
 
+    var showCancelConfirmDialog by remember { mutableStateOf(false) }
+    val isCancelEnabled = uiState is MyWaitingUiState.Success && !uiState.myWaiting.isCanceling
+    val isCancelling = uiState is MyWaitingUiState.Success && uiState.myWaiting.isCanceling
+
     Scaffold(
         modifier = modifier,
         topBar = { MyWaitingTopBar(onBack = onBack) },
+        bottomBar = {
+            Column(
+                modifier =
+                    Modifier
+                        .shadow(elevation = 10.dp, clip = false)
+                        .background(FestabookColor.white)
+                        .navigationBarsPadding(),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                WaitingCancelButton(
+                    modifier =
+                        Modifier.padding(
+                            vertical = festabookSpacing.paddingBody2,
+                            horizontal = festabookSpacing.paddingScreenGutter,
+                        ),
+                    isEnabled = isCancelEnabled,
+                    isCancelling = isCancelling,
+                    onClick = { showCancelConfirmDialog = true },
+                )
+            }
+        },
         containerColor = FestabookColor.white,
     ) { innerPadding ->
+        if (showCancelConfirmDialog) {
+            WaitingCancelConfirmDialog(
+                title = stringResource(Res.string.my_waiting_cancel_confirm_title),
+                onDismissClick = { showCancelConfirmDialog = false },
+                onCancelClick = {
+                    showCancelConfirmDialog = false
+                    onCancelWaiting()
+                },
+                onDismissRequest = { showCancelConfirmDialog = false },
+            )
+        }
         when (uiState) {
             is MyWaitingUiState.Loading -> {
                 LoadingStateScreen(modifier = Modifier.padding(innerPadding))
@@ -191,19 +229,6 @@ private fun MyWaitingContent(
                 windowInfo.containerSize.width.toDp()
             }
         }
-    var showCancelConfirmDialog by remember { mutableStateOf(false) }
-
-    if (showCancelConfirmDialog) {
-        WaitingCancelConfirmDialog(
-            title = stringResource(Res.string.my_waiting_cancel_confirm_title),
-            onDismissClick = { showCancelConfirmDialog = false },
-            onCancelClick = {
-                showCancelConfirmDialog = false
-                onCancelWaiting()
-            },
-            onDismissRequest = { showCancelConfirmDialog = false },
-        )
-    }
 
     Box(
         modifier =
@@ -279,22 +304,6 @@ private fun MyWaitingContent(
             )
 
             Spacer(modifier = Modifier.height(100.dp))
-        }
-        Column(
-            modifier =
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .requiredWidth(screenWidthDp)
-                    .background(FestabookColor.white),
-            verticalArrangement = Arrangement.Center,
-        ) {
-            WaitingCancelButton(
-                modifier =
-                    Modifier.padding(festabookSpacing.paddingScreenGutter),
-                isEnabled = !uiState.myWaiting.isCanceling,
-                isCancelling = uiState.myWaiting.isCanceling,
-                onClick = { showCancelConfirmDialog = true },
-            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/waiting/component/MyWaitingScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -120,28 +121,36 @@ fun MyWaitingScreen(
     val isCancelEnabled = uiState is MyWaitingUiState.Success && !uiState.myWaiting.isCanceling
     val isCancelling = uiState is MyWaitingUiState.Success && uiState.myWaiting.isCanceling
 
+    LaunchedEffect(uiState) {
+        if (uiState !is MyWaitingUiState.Success) {
+            showCancelConfirmDialog = false
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = { MyWaitingTopBar(onBack = onBack) },
         bottomBar = {
-            Column(
-                modifier =
-                    Modifier
-                        .shadow(elevation = 10.dp, clip = false)
-                        .background(FestabookColor.white)
-                        .navigationBarsPadding(),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                WaitingCancelButton(
+            if (uiState is MyWaitingUiState.Success) {
+                Column(
                     modifier =
-                        Modifier.padding(
-                            vertical = festabookSpacing.paddingBody2,
-                            horizontal = festabookSpacing.paddingScreenGutter,
-                        ),
-                    isEnabled = isCancelEnabled,
-                    isCancelling = isCancelling,
-                    onClick = { showCancelConfirmDialog = true },
-                )
+                        Modifier
+                            .shadow(elevation = 10.dp, clip = false)
+                            .background(FestabookColor.white)
+                            .navigationBarsPadding(),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    WaitingCancelButton(
+                        modifier =
+                            Modifier.padding(
+                                vertical = festabookSpacing.paddingBody2,
+                                horizontal = festabookSpacing.paddingScreenGutter,
+                            ),
+                        isEnabled = isCancelEnabled,
+                        isCancelling = isCancelling,
+                        onClick = { showCancelConfirmDialog = true },
+                    )
+                }
             }
         },
         containerColor = FestabookColor.white,
@@ -303,7 +312,7 @@ private fun MyWaitingContent(
                 phoneNumber = uiState.myWaiting.phoneNumber,
             )
 
-            Spacer(modifier = Modifier.height(100.dp))
+            Spacer(modifier = Modifier.height(festabookSpacing.paddingTitleHorizontal))
         }
     }
 }


### PR DESCRIPTION

## #️⃣ 이슈 번호

> ex) #149 

<br>

## 🛠️ 작업 내용

- 연예인 사진 클릭 시 확대되도록 변경하였습니다.
- 나의 웨이팅의 하단 바에 그림자를 추가하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 기존 나의 웨이팅 bottom bar에 그림자를 추가했더니 시스템 하단 바 영역으로 그림자가 새어나가는 문제가 있었습니다. 이를 Scaffold의 bottombar + navigationPadding으로 레이아웃을 시스템 바 영역까지 확장하여 해결했습니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 이미지 렌더링 컴포넌트 전환으로 안정성 및 성능 개선
  * 아티스트 이름을 활용한 접근성(대체 텍스트) 향상
  * 대기 화면의 취소 버튼 및 확인 대화상자 위치 조정으로 레이아웃/네비게이션 바 간격 개선

* **신기능**
  * 아티스트 이미지 팝업(확대 등) 기능 활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->