### PR TITLE
[Feat] 난독화 적용

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -231,12 +231,12 @@ android {
         }
 
         release {
-//            isMinifyEnabled = true
-//            isShrinkResources = true
-//            proguardFiles(
-//                getDefaultProguardFile("proguard-android-optimize.txt"),
-//                "proguard-rules.pro",
-//            )
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
             resValue("string", "app_name", "Festabook")
             signingConfig = signingConfigs["release"]
         }

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/FestabookApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/FestabookApp.kt
@@ -3,6 +3,7 @@ package com.daedan.festabook
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import com.daedan.festabook.di.AndroidAppGraph
+import com.daedan.festabook.di.coroutine.IO
 import com.daedan.festabook.domain.repository.DeviceRepository
 import com.daedan.festabook.presentation.error.FestabookGlobalExceptionHandler
 import com.daedan.festabook.service.NotificationHelper
@@ -29,6 +30,7 @@ class FestabookApp : Application() {
     private lateinit var deviceRepository: DeviceRepository
 
     @Inject
+    @IO
     private lateinit var applicationScope: CoroutineScope
 
     override fun onCreate() {

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/di/AndroidAppGraph.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.daedan.festabook.FestabookApp
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
+import com.daedan.festabook.di.coroutine.IO
 import com.daedan.festabook.presentation.splash.platform.AppVersionManager
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
@@ -19,7 +20,8 @@ interface AndroidAppGraph : FestabookAppGraph {
 
     val festivalLocalDataSource: FestivalLocalDataSource
 
-    val ioCoroutineScope: CoroutineScope
+    @IO
+    val coroutineScope: CoroutineScope
 
     @DependencyGraph.Factory
     fun interface Factory {

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/service/MyFirebaseMessagingService.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/service/MyFirebaseMessagingService.kt
@@ -20,7 +20,7 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     private val ioCoroutineScope: CoroutineScope by lazy {
-        application.androidAppGraph.ioCoroutineScope
+        application.androidAppGraph.coroutineScope
     }
 
     override fun onNewToken(token: String) {

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/data/repository/DeviceRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.daedan.festabook.data.datasource.remote.device.DeviceRemoteDataSource
 import com.daedan.festabook.data.util.randomUUID
 import com.daedan.festabook.data.util.toResult
 import com.daedan.festabook.data.util.withTimeoutOrNullFallback
+import com.daedan.festabook.di.coroutine.IO
 import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -24,7 +25,7 @@ class DeviceRepositoryImpl(
     private val deviceRemoteDataSource: DeviceRemoteDataSource,
     private val deviceLocalDataSource: DeviceLocalDataSource,
     private val fcmDataSource: FcmDataSource,
-    coroutineScope: CoroutineScope,
+    @IO coroutineScope: CoroutineScope,
 ) : DeviceRepository {
     private val cachedFcmToken: StateFlow<String?> =
         fcmDataSource.getFcmToken().stateIn(

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/FestabookAppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/FestabookAppGraph.kt
@@ -1,20 +1,9 @@
 package com.daedan.festabook.di
 
 import com.daedan.festabook.presentation.NotificationPermissionManager
-import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.Provides
-import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.SupervisorJob
 
 interface FestabookAppGraph {
     val metroViewModelFactory: MetroViewModelFactory
     val notificationPermissionManagerFactory: NotificationPermissionManager.Factory
-
-    @Provides
-    @SingleIn(AppScope::class)
-    fun provideIOCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/CoroutineBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/CoroutineBindings.kt
@@ -1,0 +1,26 @@
+package com.daedan.festabook.di.coroutine
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+object CoroutineBindings {
+    @Provides
+    @IO
+    fun provideIOCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @Main
+    fun provideMainCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    @Provides
+    @Default
+    fun provideDefaultCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/Default.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/Default.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.di.coroutine
+
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class Default

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/IO.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/IO.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.di.coroutine
+
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class IO

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/Main.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/di/coroutine/Main.kt
@@ -1,0 +1,6 @@
+package com.daedan.festabook.di.coroutine
+
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class Main

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultFirebaseMessagingDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultFirebaseMessagingDelegate.kt
@@ -2,6 +2,7 @@ package com.daedan.festabook.delegate
 
 import cocoapods.FirebaseMessaging.FIRMessaging
 import cocoapods.FirebaseMessaging.FIRMessagingDelegateProtocol
+import com.daedan.festabook.di.coroutine.IO
 import com.daedan.festabook.domain.repository.DeviceRepository
 import dev.zacsweers.metro.Inject
 import io.github.aakira.napier.Napier
@@ -14,7 +15,7 @@ import platform.darwin.NSObject
 @OptIn(ExperimentalForeignApi::class, FlowPreview::class)
 @Inject
 class DefaultFirebaseMessagingDelegate(
-    private val scope: CoroutineScope,
+    @param:IO private val scope: CoroutineScope,
     private val deviceRepository: DeviceRepository,
 ) : NSObject(),
     FIRMessagingDelegateProtocol {

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultUserNotificationDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultUserNotificationDelegate.kt
@@ -1,6 +1,7 @@
 package com.daedan.festabook.delegate
 
 import com.daedan.festabook.data.datasource.local.FestivalLocalDataSource
+import com.daedan.festabook.di.coroutine.IO
 import com.daedan.festabook.presentation.platform.DeepLinkKeys
 import com.daedan.festabook.presentation.platform.FcmDeepLinkAction
 import com.daedan.festabook.presentation.platform.FcmMessageType
@@ -23,7 +24,7 @@ import platform.darwin.NSObject
 @Inject
 class DefaultUserNotificationDelegate(
     private val festivalLocalDataSource: FestivalLocalDataSource,
-    private val ioCoroutineScope: CoroutineScope,
+    @param:IO private val coroutineScope: CoroutineScope,
 ) : NSObject(),
     UNUserNotificationCenterDelegateProtocol {
     override fun userNotificationCenter(
@@ -52,7 +53,7 @@ class DefaultUserNotificationDelegate(
                 return
             }
 
-        ioCoroutineScope.launch {
+        coroutineScope.launch {
             val currentFestivalId = festivalLocalDataSource.getFestivalId().firstOrNull()
             val festivalIdChanged =
                 newFestivalId != DeepLinkKeys.INITIALIZED_ID && newFestivalId != currentFestivalId
@@ -76,16 +77,20 @@ class DefaultUserNotificationDelegate(
         return when (type) {
             FcmMessageType.WAITING_CALL,
             FcmMessageType.WAITING_ALMOST_CALL,
-            -> FcmDeepLinkAction.OpenMyWaiting
+            -> {
+                FcmDeepLinkAction.OpenMyWaiting
+            }
 
             FcmMessageType.WAITING_PLACE_ACCESS_CANCEL -> {
-                val placeId = (this[DeepLinkKeys.KEY_PLACE_ID] as? String)?.toLongOrNull() ?: return null
+                val placeId =
+                    (this[DeepLinkKeys.KEY_PLACE_ID] as? String)?.toLongOrNull() ?: return null
                 FcmDeepLinkAction.OpenPlaceDetail(placeId)
             }
 
             FcmMessageType.ANNOUNCEMENT, null -> {
                 val announcementId =
-                    (this[DeepLinkKeys.KEY_ANNOUNCEMENT_ID] as? String)?.toLongOrNull() ?: return null
+                    (this[DeepLinkKeys.KEY_ANNOUNCEMENT_ID] as? String)?.toLongOrNull()
+                        ?: return null
                 FcmDeepLinkAction.OpenAnnouncement(announcementId)
             }
         }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -376,6 +376,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = debug.eoehdeksruf.festabook;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = festabook_distribution_debug_provisioning_profile;
+				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -417,6 +418,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = debug.eoehdeksruf.festabook;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = festabook_distribution_debug_provisioning_profile;
+				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -493,6 +495,8 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosAppRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = YES;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_DEBUG_DYLIB = NO;
@@ -512,6 +516,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = eoehdeksruf.festabook;
+				STRIP_INSTALLED_PRODUCT = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## #️⃣ 이슈 번호

#159 

<br>

## 🛠️ 작업 내용

- android 난독화 적용
- ios난독화 적용

``` markdown
### Strip Linked Product

무엇을 대상으로?

* 최종 앱 실행 파일(바이너리)

무엇을 하나?

* 링크가 끝난 완성된 바이너리에서 심볼을 제거

결과

* 함수명/클래스명 같은 식별 정보가 사라짐
* 역공학 시 의미 파악 어려워짐

⸻

### Strip Debug Symbols During Copy

무엇을 대상으로?

* 앱에 포함되는 외부 프레임워크 / 라이브러리

예:

* .framework
* .a

무엇을 하나?

* 앱 번들에 복사할 때 그 안의 디버그 심볼 제거

결과

* 서드파티 라이브러리 내부 심볼도 노출 감소

⸻

### Deployment Postprocessing

역할

* 위 두 작업을 포함한 “릴리즈 후처리 단계 자체를 활성화하는 스위치”

무엇을 하나?

* strip
* 권한 정리
* 최종 배포용 정리 작업 실행
```

<br>

## 🙇🏻 중점 리뷰 요청
- proguard.rule 파일에 어떤 내용을 제외해야할지 감이 안와서 시간이 급한대로 우선 pr올립니다.
- ios 난독화는 위의 세개의 설정을 xcode에서 적용했습니다.
- 추가로 자꾸 눈에 보여서 coroutineScope 자동주입을 빠르게 리팩토링했습니당

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * Android 릴리스 빌드에 코드 축소 및 리소스 최적화 기능 활성화로 앱 크기 감소
  * 빌드 성능 개선

* **인프라 개선**
  * 의존성 주입 시스템 개선 및 재구조화
  * iOS 빌드 구성 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->