### PR TITLE
[Fix] 네비게이션 이동 시 지도가 보이는 이슈

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
@@ -30,6 +30,7 @@ actual fun NaverMapContent(
     mapDelegate: MapDelegate,
     onMapDrag: () -> Unit,
     onMapReady: (NaverMap) -> Unit,
+    isVisible: Boolean,
     content: @Composable (NaverMap?) -> Unit,
 ) {
     val context = LocalContext.current

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -223,6 +223,7 @@ fun MainScreen(
                             }
                         }
                     },
+            isVisible = isVisible,
             placeMapViewModel = placeMapViewModel,
             locationSource = locationSource,
 //            logger = appGraph.defaultFirebaseLogger,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
@@ -11,5 +11,6 @@ expect fun NaverMapContent(
     mapDelegate: MapDelegate = MapDelegate(),
     onMapDrag: () -> Unit = {},
     onMapReady: (NaverMap) -> Unit = {},
+    isVisible: Boolean = true,
     content: @Composable (NaverMap?) -> Unit,
 )

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/PlaceMapScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/component/PlaceMapScreen.kt
@@ -57,6 +57,7 @@ fun PlaceMapRoute(
     locationSource: LocationSource,
 //    logger: DefaultFirebaseLogger,
     modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
 ) {
     val imageLoader = LocalCoilImageLoader.current
     val context = LocalPlatformContext.current
@@ -112,6 +113,7 @@ fun PlaceMapRoute(
         onEvent = { placeMapViewModel.onPlaceMapEvent(it) },
         bottomSheetState = bottomSheetState,
         mapDelegate = mapDelegate,
+        isVisible = isVisible,
     )
 }
 
@@ -122,6 +124,7 @@ fun PlaceMapScreen(
     bottomSheetState: PlaceListBottomSheetState,
     mapDelegate: MapDelegate,
     modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
 ) {
     val isPlaceListVisible = uiState.selectedPlace is LoadState.Empty
 
@@ -130,6 +133,7 @@ fun PlaceMapScreen(
         mapDelegate = mapDelegate,
         onMapReady = { onEvent(MapControlEvent.OnMapReady) },
         onMapDrag = { onEvent(MapControlEvent.OnMapDrag) },
+        isVisible = isVisible,
     ) { naverMap ->
         Column(
             modifier = Modifier.wrapContentSize(),

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/placeMap/component/NaverMapContent.kt
@@ -20,6 +20,7 @@ actual fun NaverMapContent(
     mapDelegate: MapDelegate,
     onMapDrag: () -> Unit,
     onMapReady: (NaverMap) -> Unit,
+    isVisible: Boolean,
     content: @Composable (NaverMap?) -> Unit,
 ) {
     val mapView = remember { NMFNaverMapView() }
@@ -34,6 +35,7 @@ actual fun NaverMapContent(
     Box(modifier = modifier) {
         UIKitView(
             factory = { mapView },
+            update = { view -> view.hidden = !isVisible },
             modifier = Modifier.dragInterceptor(onMapDrag),
         )
         content(mapDelegate.value)


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #164 

<br>

## 🛠️ 작업 내용
- 네비게이션 이동 시 지도가 보이는 이슈를 수정했습니다. 
- UiKitView는 Composable Tree와 별개의 렌더링 파이프라인을 가져, 가시성 제어를 별도로 두어야 합니다. iosMain의 UiKitView에 가시성 제어 로직을 추가하여 해결했습니다.  

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/d264f6e0-ce68-4edf-8353-e447c454e722
