### PR TITLE
[Fix][iOS] 플레이스 상세 > 웨이팅 등록 이동 시 잔상이 생기는 버그 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/navigation/PlaceMapNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/navigation/PlaceMapNavigation.kt
@@ -2,10 +2,6 @@ package com.daedan.festabook.presentation.placeMap.navigation
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
@@ -82,14 +78,7 @@ fun NavGraphBuilder.placeMapNavGraph(
         )
     }
 
-    composable<FestabookRoute.WaitingRegister>(
-        enterTransition = {
-            slideInVertically(initialOffsetY = { it / 10 }) + fadeIn()
-        },
-        exitTransition = {
-            slideOutVertically(targetOffsetY = { it / 10 }) + fadeOut()
-        },
-    ) { backStackEntry ->
+    composable<FestabookRoute.WaitingRegister> { backStackEntry ->
         val route = backStackEntry.toRoute<FestabookRoute.WaitingRegister>()
         val viewModel =
             assistedMetroViewModel<WaitingRegisterViewModel>(

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/waitingRegister/component/WaitingRegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/waitingRegister/component/WaitingRegisterScreen.kt
@@ -47,7 +47,6 @@ import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.PermissionState
 import com.daedan.festabook.presentation.common.ObserveAsEvents
 import com.daedan.festabook.presentation.common.component.ErrorStateScreen
-import com.daedan.festabook.presentation.common.component.LoadingStateScreen
 import com.daedan.festabook.presentation.common.component.cardBackground
 import com.daedan.festabook.presentation.placeMap.component.PlaceDetailPreviewContent
 import com.daedan.festabook.presentation.placeMap.model.PlaceUiModel
@@ -194,7 +193,8 @@ fun WaitingRegisterScreen(
 ) {
     val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)
     val state = rememberNavigationEventState(NavigationEventInfo.None)
-    val isSubmitting = (uiState as? WaitingRegisterUiState.Success)?.waitingRegister?.isSubmitting ?: false
+    val isSubmitting =
+        (uiState as? WaitingRegisterUiState.Success)?.waitingRegister?.isSubmitting ?: false
 
     NavigationBackHandler(
         state = state,
@@ -216,9 +216,7 @@ fun WaitingRegisterScreen(
             is WaitingRegisterUiState.Loading,
             is WaitingRegisterUiState.NeedsPhoneRegistration,
             -> {
-                Box(modifier = Modifier.weight(1f)) {
-                    LoadingStateScreen()
-                }
+                Unit
             }
 
             is WaitingRegisterUiState.Error -> {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #173 

<br>

## 🛠️ 작업 내용

- 플레이스 상세 > 웨이팅 등록 이동 시 잔상이 생기는 버그 해결하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)


https://github.com/user-attachments/assets/0877a42c-7c9e-4bdb-9bc9-32b9b0cc59ef

