### PR TITLE
[FIx] 지도 화면에서 요청 지연 시, 마커가 나타나지 않는 버그 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/PlaceMapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/PlaceMapViewModel.kt
@@ -126,7 +126,19 @@ class PlaceMapViewModel(
             }
 
             val placeGeographies =
-                uiState.await<LoadState.Success<List<PlaceCoordinateUiModel>>> { it.placeGeographies }
+                uiState.await<LoadState.Success<List<PlaceCoordinateUiModel>>>(
+                    onTimeout = {
+                        _uiState.update {
+                            it.copy(
+                                placeGeographies =
+                                    LoadState.Error(
+                                        IllegalStateException("서버에서 마커 정보를 가져오는 데 실패했습니다."),
+                                    ),
+                            )
+                        }
+                    },
+                ) { it.placeGeographies }
+
             _mapControlSideEffect.send(
                 MapControlSideEffect.SetMarkerByTimeTag(
                     placeGeographies = placeGeographies.value,

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/StateExt.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/state/StateExt.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(FlowPreview::class)
 suspend inline fun <reified R> StateFlow<PlaceMapUiState>.await(
-    timeout: Duration = 3.seconds,
+    timeout: Duration = 5.seconds,
     onTimeout: (Throwable) -> Unit = {},
     crossinline selector: (PlaceMapUiState) -> Any?,
 ): R =


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #176 

<br>

## 🛠️ 작업 내용

- 지도 화면에서 요청 지연 시, 마커가 나타나지 않는 버그를 개선했습니다. 
현재 특정 uiState의 프로퍼티에 의존적인 작업을 처리하기 위해 await 패턴을 사용하고 있습니다. 
이 때, 무한정 대기하는 것을 방지하기 위해, 3초의 타임아웃을 설정합니다. 이를 5초로 늘리고, 요청 실패 시, 스낵바가 뜨도록 변경했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지도 마커 초기화 중 타임아웃 발생 시 더 명확한 오류 상태 처리로 안정성 개선
  
* **개선 사항**
  * 지도 데이터 로드 대기 시간을 3초에서 5초로 증가하여 느린 네트워크 환경에서의 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->