### PR TITLE
[Fix] 지도 버튼 재 클릭 시에도 바텀시트가 내려가지 않는 버그 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/PlaceMapSideEffectHandler.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/intent/handler/PlaceMapSideEffectHandler.kt
@@ -12,7 +12,6 @@ class PlaceMapSideEffectHandler(
     private val mapManagerDelegate: MapManagerDelegate,
     private val bottomSheetState: PlaceListBottomSheetState,
     private val viewModel: PlaceMapViewModel,
-//    private val logger: DefaultFirebaseLogger,
     // 안드로이드 종속적인 액션은 외부에서 주입
     // TODO Compose로 전환 시, 콜백이 아닌 Compose State 주입
     private val onPreloadImages: (PlaceMapSideEffect.PreloadImages) -> Unit,
@@ -29,13 +28,12 @@ class PlaceMapSideEffectHandler(
 
             is PlaceMapSideEffect.MenuItemReClicked -> {
                 mapManager?.moveToPosition()
-                if (!event.isPreviewVisible) return
-                viewModel.onPlaceMapEvent(SelectEvent.UnSelectPlace)
-//                logger.log(
-//                    PlaceMapButtonReClick(
-//                        baseLogData = logger.getBaseLogData(),
-//                    ),
-//                )
+                if (bottomSheetState.settledValue == PlaceListBottomSheetValue.EXPANDED) {
+                    bottomSheetState.update(PlaceListBottomSheetValue.HALF_EXPANDED)
+                }
+                if (event.isPreviewVisible) {
+                    viewModel.onPlaceMapEvent(SelectEvent.UnSelectPlace)
+                }
             }
 
             is PlaceMapSideEffect.StartPlaceDetail -> {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #178 

<br>

## 🛠️ 작업 내용

- 바텀 시트가 완전히 펼쳐졌을 때, 지도 버튼을 누르면 접히도록 변경했습니다. 
- 이 동작을 기존 iOS Prod app을 기준으로 동작을 동일하게 설정했습니다.

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 장소 지도의 메뉴 항목 상호작용 시 하단 패널 동작 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->