### PR TITLE
[Chore] cmp-ci.yml runner를 ubuntu-latest로 전환

### DIFF
--- a/.github/workflows/cmp-ci.yml
+++ b/.github/workflows/cmp-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Run-PR-Test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -38,7 +38,6 @@ import com.daedan.festabook.presentation.common.component.FestabookSwitch
 import com.daedan.festabook.presentation.common.component.FestabookTopAppBar
 import com.daedan.festabook.presentation.home.FestivalUiState
 import com.daedan.festabook.presentation.home.HomeViewModel
-import com.daedan.festabook.presentation.home.model.FestatingUiModel
 import com.daedan.festabook.presentation.home.model.FestivalUiModel
 import com.daedan.festabook.presentation.home.model.OrganizationUiModel
 import com.daedan.festabook.presentation.setting.SettingViewModel

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
@@ -39,7 +39,7 @@ private val FAKE_FESTIVAL_RESPONSE =
         festivalSponsors = emptyList(),
         instagramLink = null,
         homepageLink = null,
-        festatingVisible = true
+        festatingVisible = true,
     )
 
 @Suppress("UNCHECKED_CAST")

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/viewModel/placeMap/PlaceMapViewModelTest.kt
@@ -188,7 +188,10 @@ class PlaceMapViewModelTest {
                 Result.success(
                     FAKE_ORGANIZATION_GEOGRAPHY,
                 )
-            everySuspend { placeListRepository.getPlaceGeographies() } returns Result.failure(exception)
+            everySuspend { placeListRepository.getPlaceGeographies() } returns
+                Result.success(
+                    FAKE_PLACE_GEOGRAPHIES,
+                )
 
             // when
             placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)
@@ -196,8 +199,11 @@ class PlaceMapViewModelTest {
 
             // then
             val uiState = placeMapViewModel.uiState.value
-            assertEquals(LoadState.Success(FAKE_ORGANIZATION_GEOGRAPHY.toUiModel()), uiState.initialMapSetting)
-            assertEquals(LoadState.Error(exception), uiState.placeGeographies)
+            assertEquals(
+                LoadState.Success(FAKE_ORGANIZATION_GEOGRAPHY.toUiModel()),
+                uiState.initialMapSetting,
+            )
+            assertEquals(ListLoadState.Error(exception), uiState.places)
         }
 
     @Test
@@ -245,7 +251,10 @@ class PlaceMapViewModelTest {
         runTest {
             // given
             val throwable = Throwable()
-            everySuspend { placeListRepository.getPlaceGeographies() } returns Result.failure(throwable)
+            everySuspend { placeListRepository.getPlaceGeographies() } returns
+                Result.failure(
+                    throwable,
+                )
 
             // when
             placeMapViewModel = PlaceMapViewModel(placeListRepository, handlerGraphFactory)


### PR DESCRIPTION
## 개요

`cmp-ci.yml` (PR 검증 워크플로우)의 runner를 self-hosted에서 hosted(`ubuntu-latest`)로 전환하여 PR 피드백 지연 문제를 해소합니다.

## 변경 사항

- `.github/workflows/cmp-ci.yml`: `runs-on: self-hosted` → `runs-on: ubuntu-latest`

```diff
   Run-PR-Test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
```

## 변경 이유

- self-hosted runner에서 `cmp-ci.yml` 평균 실행 시간이 약 **21.3분**으로, hosted(`ubuntu-latest`) 평균 **7.1분** 대비 약 3배 느림
- 원인: self-hosted 머신 CPU 성능 한계(i3-6100, 컨테이너당 2코어). Gradle 빌드 같은 CPU 바운드 작업에서 격차가 큼
- 5월 GitHub Actions 무료 한도(2,000분/월) 초기화에 맞춰 워크플로우 분리 전략 적용
  - **무거운 빌드 (PR 검증 등)** → hosted runner
  - **Claude API / Slack 알림 / release drafter** → self-hosted 유지 (API 대기 시간이 대부분이라 hosted/self-hosted 차이 없음)
- 본 레포에서 hosted로 옮길 대상은 `cmp-ci.yml` 한 파일

## 예상 효과

- PR 1건당 CI 대기 시간 약 21분 → 7~10분 (약 3배 단축)
- self-hosted runner는 가벼운 작업만 처리하므로 queue 대기 거의 없음
- 월 hosted 차감량 약 227분 (전체 합산 약 1,439분/2,000분 한도 내)

## 테스트 방법

- [ ] 본 PR 생성 시 트리거되는 `cmp-ci.yml`이 `ubuntu-latest` runner에서 실행되는지 GitHub Actions UI에서 확인
- [ ] 모든 step (ktlint, BuildKonfig 생성, Unit Test, 결과 publish) 정상 통과 확인
- [ ] 시크릿 주입 step (`Create local.properties`, `Load Google Service file`, `Restore keystore file`) 에러 없이 동작 확인
- [ ] 총 실행 시간이 기존 self-hosted 21분 대비 7~10분대로 단축됨을 확인

## 관련 이슈

closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI 빌드 환경을 GitHub 호스트 러너(ubuntu-latest)로 전환해 인프라 안정성과 유지 관리를 개선했습니다.
  * 불필요한 임포트 제거 등 코드 정리 작업을 수행했습니다.
* **Tests**
  * 테스트 데이터 형식과 일부 단위 테스트의 시뮬레이션/검증을 정리하고 포맷을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->