### PR TITLE
[Fix]: 웹뷰 내 토스(Toss) 결제 연동을 위한 외부 스킴 처리 로직 추가

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,7 +3,11 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    
+    <queries>
+        <package android:name="viva.republica.toss" />
+    </queries>
+
+
 
     <application
         android:name=".FestabookApp"

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/AndroidWebViewClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/AndroidWebViewClient.kt
@@ -1,0 +1,34 @@
+package com.daedan.festabook.presentation.festating.component.platfom
+
+import android.content.Intent
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.core.net.toUri
+import com.multiplatform.webview.web.AccompanistWebViewClient
+
+object AndroidWebViewClient : AccompanistWebViewClient() {
+    override fun shouldOverrideUrlLoading(
+        view: WebView?,
+        request: WebResourceRequest?,
+    ): Boolean {
+        if (view == null || request == null) return false
+        val url = request.url
+
+        url.scheme?.takeIf { it == TOSS_SCHEME || it == "intent" }?.let {
+            val intent = Intent.parseUri(url.toString(), Intent.URI_INTENT_SCHEME)
+            val packageManager = view.context.packageManager
+            if (intent.resolveActivity(packageManager) != null) {
+                view.context.startActivity(intent)
+                return true
+            }
+
+            val packageName = intent.`package` ?: TOSS_PACKAGE_NAME
+            val marketIntent = Intent(Intent.ACTION_VIEW, "market://details?id=$packageName".toUri())
+            view.context.startActivity(marketIntent)
+            return true
+        }
+        return false
+    }
+
+    private const val TOSS_PACKAGE_NAME = "viva.republica.toss"
+}

--- a/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.android.kt
@@ -1,0 +1,32 @@
+package com.daedan.festabook.presentation.festating.component.platfom
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.multiplatform.webview.web.PlatformWebViewParams
+import com.multiplatform.webview.web.WebView
+import com.multiplatform.webview.web.WebViewNavigator
+import com.multiplatform.webview.web.WebViewState
+
+@Composable
+actual fun FestatingWebView(
+    webViewState: WebViewState,
+    navigator: WebViewNavigator,
+    innerPadding: PaddingValues,
+    modifier: Modifier,
+) {
+    WebView(
+        state = webViewState,
+        navigator = navigator,
+        modifier =
+            Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+        platformWebViewParams =
+            PlatformWebViewParams(
+                client = AndroidWebViewClient,
+            ),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/festating/component/FestatingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/festating/component/FestatingScreen.kt
@@ -1,7 +1,5 @@
 package com.daedan.festabook.presentation.festating.component
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,7 +14,7 @@ import com.daedan.festabook.presentation.common.component.ErrorStateScreen
 import com.daedan.festabook.presentation.common.component.LoadingStateScreen
 import com.daedan.festabook.presentation.festating.FestatingUiState
 import com.daedan.festabook.presentation.festating.FestatingViewModel
-import com.multiplatform.webview.web.WebView
+import com.daedan.festabook.presentation.festating.component.platfom.FestatingWebView
 import com.multiplatform.webview.web.WebViewState
 import com.multiplatform.webview.web.rememberWebViewNavigator
 import com.multiplatform.webview.web.rememberWebViewState
@@ -64,13 +62,10 @@ fun FestatingScreen(
             }
 
             Scaffold(modifier = modifier) { innerPadding ->
-                WebView(
-                    state = webViewState,
+                FestatingWebView(
+                    webViewState = webViewState,
                     navigator = navigator,
-                    modifier =
-                        Modifier
-                            .padding(innerPadding)
-                            .fillMaxSize(),
+                    innerPadding = innerPadding,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.kt
@@ -1,0 +1,17 @@
+package com.daedan.festabook.presentation.festating.component.platfom
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.multiplatform.webview.web.WebViewNavigator
+import com.multiplatform.webview.web.WebViewState
+
+@Composable
+expect fun FestatingWebView(
+    webViewState: WebViewState,
+    navigator: WebViewNavigator,
+    innerPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+)
+
+const val TOSS_SCHEME = "supertoss"

--- a/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/daedan/festabook/data/datasource/remote/festival/FestivalRemoteDataSourceTest.kt
@@ -39,7 +39,7 @@ private val FAKE_FESTIVAL_RESPONSE =
         festivalSponsors = emptyList(),
         instagramLink = null,
         homepageLink = null,
-        festatingVisible = true
+        festatingVisible = true,
     )
 
 @Suppress("UNCHECKED_CAST")

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultWKNavigationDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/delegate/DefaultWKNavigationDelegate.kt
@@ -1,0 +1,60 @@
+package com.daedan.festabook.delegate
+
+import com.daedan.festabook.presentation.festating.component.platfom.TOSS_SCHEME
+import io.github.aakira.napier.Napier
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.WebKit.WKNavigationAction
+import platform.WebKit.WKNavigationActionPolicy
+import platform.WebKit.WKNavigationDelegateProtocol
+import platform.WebKit.WKWebView
+import platform.darwin.NSObject
+
+@OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+class DefaultWKNavigationDelegate :
+    NSObject(),
+    WKNavigationDelegateProtocol {
+    override fun webView(
+        webView: WKWebView,
+        decidePolicyForNavigationAction: WKNavigationAction,
+        decisionHandler: (WKNavigationActionPolicy) -> Unit,
+    ) {
+        val url = decidePolicyForNavigationAction.request.URL
+        val scheme = url?.scheme
+
+        Napier.d("scheme:$scheme")
+        scheme.takeIf { it == TOSS_SCHEME }?.let {
+            url?.let { nsUrl ->
+                Napier.d("nsUrl:$nsUrl")
+                openUrl(nsUrl) {
+                    // Kotlin Native에서 objc의 하위 타입은 필드 사용 불가
+                    (
+                        NSURL.URLWithString("itms-apps://itunes.apple.com/app/id839333328")?.let {
+                            openUrl(it)
+                        }
+                    )
+                }
+            }
+            decisionHandler(WKNavigationActionPolicy.WKNavigationActionPolicyCancel)
+            return
+        }
+        decisionHandler(WKNavigationActionPolicy.WKNavigationActionPolicyAllow)
+    }
+
+    private fun openUrl(
+        url: NSURL,
+        onFailure: () -> Unit = {},
+    ) {
+        UIApplication.sharedApplication.openURL(
+            url = url,
+            options = emptyMap<Any?, Any?>(),
+            completionHandler = { success ->
+                if (!success) {
+                    onFailure()
+                }
+            },
+        )
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/festating/component/platfom/FestatingWebView.ios.kt
@@ -1,0 +1,46 @@
+package com.daedan.festabook.presentation.festating.component.platfom
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import com.daedan.festabook.delegate.DefaultWKNavigationDelegate
+import com.multiplatform.webview.web.WebView
+import com.multiplatform.webview.web.WebViewNavigator
+import com.multiplatform.webview.web.WebViewState
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectZero
+import platform.WebKit.WKNavigationDelegateProtocol
+import platform.WebKit.WKWebView
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun FestatingWebView(
+    webViewState: WebViewState,
+    navigator: WebViewNavigator,
+    innerPadding: PaddingValues,
+    modifier: Modifier,
+) {
+    val wrappedDelegateWkNavigationDelegate =
+        remember {
+            DefaultWKNavigationDelegate()
+        }
+    WebView(
+        state = webViewState,
+        navigator = navigator,
+        modifier =
+            Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+        factory = { param ->
+            object : WKWebView(frame = CGRectZero.readValue(), configuration = param.config) {
+                override fun setNavigationDelegate(navigationDelegate: WKNavigationDelegateProtocol?) {
+                    super.setNavigationDelegate(wrappedDelegateWkNavigationDelegate)
+                }
+            }
+        },
+    )
+}

--- a/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/setting/component/platform/RememberOpenAppSettings.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/daedan/festabook/presentation/setting/component/platform/RememberOpenAppSettings.ios.kt
@@ -4,13 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
 
 @Composable
 actual fun rememberOpenAppSettings(): () -> Unit =
     remember {
         {
             val url =
-                NSURL.URLWithString("app-settings:") ?: return@remember
+                NSURL.URLWithString(UIApplicationOpenSettingsURLString) ?: return@remember
             UIApplication.sharedApplication.openURL(url, mapOf<Any?, Any?>(), null)
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ kotlin.native.binary.stripDebugSymbols=false
 kotlin.native.cacheKind=static
 kotlin.native.disableCompilerDaemon=false
 
-buildkonfig.flavor=release
+buildkonfig.flavor=dev
 
 APP_VERSION_NAME=2.1.1
 APP_VERSION_CODE=2010103

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -1,22 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-	<false/>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>itms-apps</string>
-	</array>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
-<key>CFBundleShortVersionString</key>
+    <dict>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true />
+        <key>FirebaseAppDelegateProxyEnabled</key>
+        <false />
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+            <string>itms-apps</string>
+        </array>
+        <key>UIBackgroundModes</key>
+        <array>
+            <string>remote-notification</string>
+        </array>
+        <key>CFBundleShortVersionString</key>
 		<string>2.1.1</string>
-<key>CFBundleVersion</key>
+        <key>CFBundleVersion</key>
 		<string>2010103</string>
-</dict>
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+            <string>supertoss</string>
+        </array>
+
+    </dict>
 </plist>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #187 

<br>

## 🛠️ 작업 내용

- 페스타팅 결제 시, 커스텀 딥링크가 작동하지 않는 문제를 해결했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

# iOS 실기기에서 꼭 테스트 부탁드립니다..!!!!! 토스 앱 + 앱스토어가 시뮬레이터에 없어서 테스트가 안된 상황이에요. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹뷰에서 외부 결제 애플리케이션을 직접 실행할 수 있도록 지원합니다. 앱에서 지원하지 않는 경우 스토어 페이지로 연결됩니다.

* **리팩토링**
  * 웹뷰 컴포넌트를 플랫폼별 구현으로 분리하여 코드 구조를 개선했습니다.

* **기타**
  * 빌드 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->