### PR TITLE
[Fix][iOS] 웨이팅 등록 시, 권한 거부 상태일 때, 설정 창으로 이동하지 않는 이슈

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/waitingRegister/component/WaitingRegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/placeMap/waitingRegister/component/WaitingRegisterScreen.kt
@@ -108,7 +108,9 @@ fun WaitingRegisterRoute(
                 settingViewModel.saveNotificationId()
                 viewModel.submitWaitingRegister()
             },
-            onPermissionDeny = {},
+            onPermissionDeny = {
+                onOpenAppSettings()
+            },
         )
 
     ObserveAsEvents(viewModel.registerSuccessEvent) {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #189

<br>

## 🛠️ 작업 내용

- 웨이팅 등록 시, 권한 거부 상태일 때, 설정 창으로 이동하지 않는 이슈를 해결합니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 권한 거부 시 앱 설정이 자동으로 열리도록 개선했습니다. 이전에는 권한 거부 후 별다른 조치가 없었으나, 이제 사용자가 설정을 통해 권한을 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->