### PR TITLE
[Fix] 메인 네비게이션 탭 전환 시 깜빡임 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -1,5 +1,7 @@
 package com.daedan.festabook.presentation.main.component
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -283,6 +285,10 @@ private fun FestabookNavHost(
         modifier = modifier,
         startDestination = navigator.startRoute,
         navController = navigator.navController,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
+        popEnterTransition = { EnterTransition.None },
+        popExitTransition = { ExitTransition.None },
     ) {
         homeNavGraph(
             innerPadding = innerPadding,

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ kotlin.native.binary.stripDebugSymbols=false
 kotlin.native.cacheKind=static
 kotlin.native.disableCompilerDaemon=false
 
-buildkonfig.flavor=release
+buildkonfig.flavor=dev
 
 APP_VERSION_NAME=2.1.1
 APP_VERSION_CODE=2010103


### PR DESCRIPTION
## #️⃣ 이슈 번호

> ex) #168
<br>

## 🛠️ 작업 내용

- 메인 네비게이션 탭 전환 시 깜빡임을 해결했습니다. 
<br>

## 🙇🏻 중점 리뷰 요청

- popupTo로 이동하는 경우 애니메이션이 popExitTransition을사 사용하기 때문에 해당 부분을 NONE으로 설정하였습니다. 

https://github.com/user-attachments/assets/ddc6167c-7e9c-46ab-b944-66a8bae6242e

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
